### PR TITLE
Fix preTest.sh for node impl

### DIFF
--- a/impls/node/preTest.sh
+++ b/impls/node/preTest.sh
@@ -1,4 +1,4 @@
 #! /usr/bin/env bash
 
-cp ./serviceDefs.ts ./impls/bun/serviceDefs.ts
+cp ./serviceDefs.ts ./impls/node/serviceDefs.ts
 echo 'done'


### PR DESCRIPTION
The preTest.sh script copies the service defs to the bun impl instead of the node impl.
