### PR TITLE
Use randomized container names

### DIFF
--- a/impls/node/client.ts
+++ b/impls/node/client.ts
@@ -15,6 +15,7 @@ const {
   HEARTBEAT_MS,
   HEARTBEATS_UNTIL_DEAD,
   SESSION_DISCONNECT_GRACE_MS,
+  RIVER_SERVER,
 } = process.env as Record<string, string>;
 const transportOptions: Partial<TransportOptions> = {
   codec: BinaryCodec,
@@ -30,7 +31,7 @@ bindLogger(
 );
 
 const clientTransport = new WebSocketClientTransport(
-  () => Promise.resolve(new WebSocket(`ws://river-server:${PORT}`)),
+  () => Promise.resolve(new WebSocket(`ws://${RIVER_SERVER}:${PORT}`)),
   CLIENT_TRANSPORT_ID,
   transportOptions,
 );

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from "crypto";
 import chalk from "chalk";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
@@ -124,7 +125,9 @@ async function runSuite(
     }
 
     console.log(chalk.yellow(`[${name}] setup`));
+    const testId = randomBytes(8).toString("hex");
     const serverContainer = await setupContainer(
+      testId,
       clientImpl,
       serverImpl,
       "server",
@@ -139,6 +142,7 @@ async function runSuite(
         // client case
         const { actions, expectedOutput } = testEntry;
         const container = await setupContainer(
+          testId,
           clientImpl,
           serverImpl,
           "client",


### PR DESCRIPTION
Using randomized container names will allow us to run tests concurrently.
It also allows us to enable autoremove which provides for slightly more robust cleanup.

I also removed an artificial timeout after starting each container since that should not be necessary.
