### PR TITLE
Fix river server in bun/python clients

### DIFF
--- a/impls/bun/client.ts
+++ b/impls/bun/client.ts
@@ -15,6 +15,7 @@ const {
   HEARTBEAT_MS,
   HEARTBEATS_UNTIL_DEAD,
   SESSION_DISCONNECT_GRACE_MS,
+  RIVER_SERVER,
 } = process.env as Record<string, string>;
 const transportOptions: Partial<TransportOptions> = {
   codec: BinaryCodec,
@@ -30,7 +31,7 @@ bindLogger(
 );
 
 const clientTransport = new WebSocketClientTransport(
-  () => Promise.resolve(new WebSocket(`ws://river-server:${PORT}`)),
+  () => Promise.resolve(new WebSocket(`ws://${RIVER_SERVER}:${PORT}`)),
   CLIENT_TRANSPORT_ID,
   transportOptions,
 );

--- a/impls/python/client.py
+++ b/impls/python/client.py
@@ -29,6 +29,7 @@ SERVER_TRANSPORT_ID = os.getenv("SERVER_TRANSPORT_ID")
 HEARTBEAT_MS = int(os.getenv("HEARTBEAT_MS", "500"))
 HEARTBEATS_UNTIL_DEAD = int(os.getenv("HEARTBEATS_UNTIL_DEAD", "2"))
 SESSION_DISCONNECT_GRACE_MS = int(os.getenv("SESSION_DISCONNECT_GRACE_MS", "3000"))
+RIVER_SERVER = os.getenv("RIVER_SERVER")
 
 
 logging.basicConfig(
@@ -43,7 +44,7 @@ tasks: Dict[str, asyncio.Task] = {}
 
 async def process_commands():
     logging.error("start python river client")
-    uri = f"ws://river-server:{PORT}"
+    uri = f"ws://{RIVER_SERVER}:{PORT}"
     logging.error(
         "Heartbeat: %d ms, Heartbeats to dead: %d, Session disconnect grace: %d ms",
         HEARTBEAT_MS,


### PR DESCRIPTION
Oops right after merging #22, I realized I forgot to update the other clients to use `RIVER_SERVER`.

Once tests are passing more consistently this shouldn't be as error prone.
