### PR TITLE
[dev] `/healthz`

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ cross-language test-suite
 ## running tests
 
 - `npm run start -- --client <impl> --server <impl>`
-  - you can see valid impls under `impls` (currently `python` and `bun`)
+  - you can see valid impls under `impls` (currently `python` and `node`, although apparently `bun`
+    still works for the time being).
 - if you are planning on running python tests, you should clone the `python-river`
   submodule: `git submodule update --init`
 

--- a/impls/bun/server.ts
+++ b/impls/bun/server.ts
@@ -27,7 +27,14 @@ bindLogger(
   "debug",
 );
 
-const httpServer = http.createServer();
+const httpServer = http.createServer((req, res) => {
+  if (req.url === "/healthz") {
+    res.end("OK");
+    return;
+  }
+  res.statusCode = 426;
+  res.end("Upgrade required");
+});
 const wss = new WebSocketServer({ server: httpServer });
 const transport = new WebSocketServerTransport(
   wss,

--- a/impls/node/client.ts
+++ b/impls/node/client.ts
@@ -31,7 +31,15 @@ bindLogger(
 );
 
 const clientTransport = new WebSocketClientTransport(
-  () => Promise.resolve(new WebSocket(`ws://${RIVER_SERVER}:${PORT}`)),
+  () =>
+    (async (): Promise<WsLike> => {
+      const ws = new WebSocket(`ws://${RIVER_SERVER}:${PORT}`);
+      // Explicitly set an error handler to avoid unhandled exceptions.
+      ws.on("error", (err) => {
+        console.error(err);
+      });
+      return ws;
+    })(),
   CLIENT_TRANSPORT_ID,
   transportOptions,
 );

--- a/impls/node/server.ts
+++ b/impls/node/server.ts
@@ -27,7 +27,14 @@ bindLogger(
   "debug",
 );
 
-const httpServer = http.createServer();
+const httpServer = http.createServer((req, res) => {
+  if (req.url === "/healthz") {
+    res.end("OK");
+    return;
+  }
+  res.statusCode = 426;
+  res.end("Upgrade required");
+});
 const wss = new WebSocketServer({ server: httpServer });
 const transport = new WebSocketServerTransport(
   wss,


### PR DESCRIPTION
We currently have some races that cause some of the test cases to fail because the server takes several seconds to warm up and be truly ready.

This change adds a `/healthz` endpoint that responds to HTTP so that the Docker driver can accurately wait until the container is ready. It also stops making the Docker containers autoremovable, because that causes some systems to tear down the container too fast and they cannot be restarted effectively.