### PR TITLE
Run tests in parallel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "dependencies": {
         "@replit/river": "^0.23.1",
         "@sinclair/typebox": "^0.32.20",
+        "@supercharge/promise-pool": "^3.2.0",
         "chalk": "^5.3.0",
         "diff": "^5.2.0",
         "docker-modem": "^5.0.3",
@@ -433,6 +434,14 @@
     "node_modules/@sinclair/typebox": {
       "version": "0.32.20",
       "license": "MIT"
+    },
+    "node_modules/@supercharge/promise-pool": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@supercharge/promise-pool/-/promise-pool-3.2.0.tgz",
+      "integrity": "sha512-pj0cAALblTZBPtMltWOlZTQSLT07jIaFNeM8TWoJD1cQMgDB9mcMlVMoetiB35OzNJpqQ2b+QEtwiR9f20mADg==",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/@types/diff": {
       "version": "5.0.9",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@replit/river": "^0.23.1",
     "@sinclair/typebox": "^0.32.20",
+    "@supercharge/promise-pool": "^3.2.0",
     "chalk": "^5.3.0",
     "diff": "^5.2.0",
     "docker-modem": "^5.0.3",


### PR DESCRIPTION
Running all the tests serially is super slow. In a previous PR I made it so all the containers use randomized names, so they can run concurrently without stomping on each other.

This makes it so we actually run all the tests concurrently using a `PromisePool` which allows for configurable concurrency limits.

The test output is performed in a non-async function to ensure that test results logs/ouput don't get interleaved.
