### PR TITLE
[dev] Mark test as flaky

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -119,13 +119,16 @@ export function serializeExpectedOutputEntry(entry: ExpectedOutputEntry) {
   return `${entry.id} -- ${entry.status}:${entry.payload}`;
 }
 
-export type Test = Record<
-  string,
-  | {
+export type Test = {
+  clients: Record<
+    string,
+    {
       actions: Action[];
       expectedOutput: ExpectedOutputEntry[];
     }
-  | {
-      serverActions: Exclude<Action, InvokeActions>[];
-    }
->;
+  >;
+  server?: {
+    serverActions: Exclude<Action, InvokeActions>[];
+  };
+  flaky?: boolean;
+};

--- a/src/docker.ts
+++ b/src/docker.ts
@@ -235,21 +235,21 @@ export async function setupContainer(
       const c = docker.getContainer(containerId);
       try {
         await c.stop({ t: 5 });
-      } catch (err) {
+      } catch (err: any) {
         // If the container is already stopped, let it be.
-        if (err.statusCode === 304) return;
+        if ("statusCode" in err && err.statusCode === 304) return;
         throw err;
       }
       try {
         await c.remove({ force: true });
-      } catch (err) {
+      } catch (err: any) {
         // If the removal is already in progress, let it be.
-        if (err.statusCode === 409) return;
+        if ("statusCode" in err && err.statusCode === 409) return;
         throw err;
       }
-    } catch (err) {
+    } catch (err: any) {
       // If the container was not found, let it be.
-      if (err.statusCode === 404) return;
+      if ("statusCode" in err && err.statusCode === 404) return;
       throw err;
     }
   };
@@ -263,7 +263,7 @@ export async function setupContainer(
     for (let remaining = 100; remaining >= 0; remaining--) {
       try {
         // We just need for the fetch to give us something that looks like HTTP back.
-        await fetch(address, { header: { Connection: "close" } });
+        await fetch(address, { headers: { Connection: "close" } });
         break;
       } catch (err) {
         if (remaining === 0) {

--- a/tests/basic/echo.ts
+++ b/tests/basic/echo.ts
@@ -1,45 +1,59 @@
 import type { Test } from "../../src/actions";
 
 const RepeatEchoTest: Test = {
-  client: {
-    actions: [
-      { type: "invoke", id: "1", proc: "repeat.echo", init: {} },
-      { type: "invoke", id: "1", proc: "repeat.echo", payload: { s: "hello" } },
-      { type: "invoke", id: "1", proc: "repeat.echo", payload: { s: "world" } },
-    ],
-    expectedOutput: [
-      { id: "1", status: "ok", payload: "hello" },
-      { id: "1", status: "ok", payload: "world" },
-    ],
+  clients: {
+    client: {
+      actions: [
+        { type: "invoke", id: "1", proc: "repeat.echo", init: {} },
+        {
+          type: "invoke",
+          id: "1",
+          proc: "repeat.echo",
+          payload: { s: "hello" },
+        },
+        {
+          type: "invoke",
+          id: "1",
+          proc: "repeat.echo",
+          payload: { s: "world" },
+        },
+      ],
+      expectedOutput: [
+        { id: "1", status: "ok", payload: "hello" },
+        { id: "1", status: "ok", payload: "world" },
+      ],
+    },
   },
 };
 
 const RepeatEchoPrefixTest: Test = {
-  client: {
-    actions: [
-      {
-        type: "invoke",
-        id: "1",
-        proc: "repeat.echo_prefix",
-        init: { prefix: "prefix: " },
-      },
-      {
-        type: "invoke",
-        id: "1",
-        proc: "repeat.echo_prefix",
-        payload: { str: "hello" },
-      },
-      {
-        type: "invoke",
-        id: "1",
-        proc: "repeat.echo_prefix",
-        payload: { str: "world" },
-      },
-    ],
-    expectedOutput: [
-      { id: "1", status: "ok", payload: "prefix: hello" },
-      { id: "1", status: "ok", payload: "prefix: world" },
-    ],
+  clients: {
+    client: {
+      actions: [
+        {
+          type: "invoke",
+          id: "1",
+          proc: "repeat.echo_prefix",
+          init: { prefix: "prefix: " },
+        },
+        {
+          type: "invoke",
+          id: "1",
+          proc: "repeat.echo_prefix",
+          payload: { str: "hello" },
+        },
+        {
+          type: "invoke",
+          id: "1",
+          proc: "repeat.echo_prefix",
+          payload: { str: "world" },
+        },
+      ],
+      expectedOutput: [
+        { id: "1", status: "ok", payload: "prefix: hello" },
+        { id: "1", status: "ok", payload: "prefix: world" },
+      ],
+    },
   },
 };
 

--- a/tests/basic/kv.ts
+++ b/tests/basic/kv.ts
@@ -2,123 +2,205 @@ import type { Test } from "../../src/actions";
 import { SESSION_DISCONNECT_MS } from "../constants";
 
 const KvRpcTest: Test = {
-  client: {
-    actions: [
-      { type: "invoke", id: "1", proc: "kv.set", payload: { k: "foo", v: 42 } },
-      { type: "invoke", id: "2", proc: "kv.set", payload: { k: "foo", v: 43 } },
-      { type: "invoke", id: "3", proc: "kv.set", payload: { k: "abc", v: 1 } },
-    ],
-    expectedOutput: [
-      { id: "1", status: "ok", payload: 42 },
-      { id: "2", status: "ok", payload: 43 },
-      { id: "3", status: "ok", payload: 1 },
-    ],
+  clients: {
+    client: {
+      actions: [
+        {
+          type: "invoke",
+          id: "1",
+          proc: "kv.set",
+          payload: { k: "foo", v: 42 },
+        },
+        {
+          type: "invoke",
+          id: "2",
+          proc: "kv.set",
+          payload: { k: "foo", v: 43 },
+        },
+        {
+          type: "invoke",
+          id: "3",
+          proc: "kv.set",
+          payload: { k: "abc", v: 1 },
+        },
+      ],
+      expectedOutput: [
+        { id: "1", status: "ok", payload: 42 },
+        { id: "2", status: "ok", payload: 43 },
+        { id: "3", status: "ok", payload: 1 },
+      ],
+    },
   },
 };
 
 const KvSubscribeTest: Test = {
-  client: {
-    actions: [
-      { type: "invoke", id: "1", proc: "kv.set", payload: { k: "foo", v: 42 } },
-      { type: "invoke", id: "2", proc: "kv.watch", payload: { k: "foo" } },
-      { type: "invoke", id: "3", proc: "kv.set", payload: { k: "abc", v: 1 } },
-      { type: "invoke", id: "4", proc: "kv.set", payload: { k: "foo", v: 43 } },
-    ],
-    expectedOutput: [
-      { id: "1", status: "ok", payload: 42 },
-      { id: "2", status: "ok", payload: 42 }, // watch should return the current value
-      { id: "3", status: "ok", payload: 1 },
-      { id: "2", status: "ok", payload: 43 },
-      { id: "4", status: "ok", payload: 43 },
-    ],
+  clients: {
+    client: {
+      actions: [
+        {
+          type: "invoke",
+          id: "1",
+          proc: "kv.set",
+          payload: { k: "foo", v: 42 },
+        },
+        { type: "invoke", id: "2", proc: "kv.watch", payload: { k: "foo" } },
+        {
+          type: "invoke",
+          id: "3",
+          proc: "kv.set",
+          payload: { k: "abc", v: 1 },
+        },
+        {
+          type: "invoke",
+          id: "4",
+          proc: "kv.set",
+          payload: { k: "foo", v: 43 },
+        },
+      ],
+      expectedOutput: [
+        { id: "1", status: "ok", payload: 42 },
+        { id: "2", status: "ok", payload: 42 }, // watch should return the current value
+        { id: "3", status: "ok", payload: 1 },
+        { id: "2", status: "ok", payload: 43 },
+        { id: "4", status: "ok", payload: 43 },
+      ],
+    },
   },
 };
 
 const KvSubscribeErrorTest: Test = {
-  client: {
-    actions: [
-      { type: "invoke", id: "1", proc: "kv.watch", payload: { k: "foo" } },
-    ],
-    expectedOutput: [{ id: "1", status: "err", payload: "NOT_FOUND" }],
+  clients: {
+    client: {
+      actions: [
+        { type: "invoke", id: "1", proc: "kv.watch", payload: { k: "foo" } },
+      ],
+      expectedOutput: [{ id: "1", status: "err", payload: "NOT_FOUND" }],
+    },
   },
 };
 
 const KvSubscribeMultipleTest: Test = {
-  client1: {
-    actions: [
-      { type: "invoke", id: "1", proc: "kv.set", payload: { k: "foo", v: 42 } },
-      { type: "invoke", id: "2", proc: "kv.watch", payload: { k: "foo" } },
-      { type: "invoke", id: "3", proc: "kv.set", payload: { k: "foo", v: 43 } },
-    ],
-    expectedOutput: [
-      // set foo 42
-      { id: "1", status: "ok", payload: 42 },
-      // watch foo
-      { id: "2", status: "ok", payload: 42 },
+  clients: {
+    client1: {
+      actions: [
+        {
+          type: "invoke",
+          id: "1",
+          proc: "kv.set",
+          payload: { k: "foo", v: 42 },
+        },
+        { type: "invoke", id: "2", proc: "kv.watch", payload: { k: "foo" } },
+        {
+          type: "invoke",
+          id: "3",
+          proc: "kv.set",
+          payload: { k: "foo", v: 43 },
+        },
+      ],
+      expectedOutput: [
+        // set foo 42
+        { id: "1", status: "ok", payload: 42 },
+        // watch foo
+        { id: "2", status: "ok", payload: 42 },
 
-      // set foo 43
-      { id: "2", status: "ok", payload: 43 },
-      { id: "3", status: "ok", payload: 43 },
+        // set foo 43
+        { id: "2", status: "ok", payload: 43 },
+        { id: "3", status: "ok", payload: 43 },
 
-      // from client2 setting foo to 41
-      { id: "2", status: "ok", payload: 41 },
-    ],
-  },
-  client2: {
-    actions: [
-      { type: "wait", ms: 800 },
-      { type: "invoke", id: "a", proc: "kv.watch", payload: { k: "foo" } },
-      { type: "invoke", id: "b", proc: "kv.set", payload: { k: "foo", v: 41 } },
-    ],
-    expectedOutput: [
-      // watch foo
-      { id: "a", status: "ok", payload: 43 },
+        // from client2 setting foo to 41
+        { id: "2", status: "ok", payload: 41 },
+      ],
+    },
+    client2: {
+      actions: [
+        { type: "wait", ms: 800 },
+        { type: "invoke", id: "a", proc: "kv.watch", payload: { k: "foo" } },
+        {
+          type: "invoke",
+          id: "b",
+          proc: "kv.set",
+          payload: { k: "foo", v: 41 },
+        },
+      ],
+      expectedOutput: [
+        // watch foo
+        { id: "a", status: "ok", payload: 43 },
 
-      // set foo 41
-      { id: "a", status: "ok", payload: 41 },
-      { id: "b", status: "ok", payload: 41 },
-    ],
+        // set foo 41
+        { id: "a", status: "ok", payload: 41 },
+        { id: "b", status: "ok", payload: 41 },
+      ],
+    },
   },
 };
 
 const KvLongSubscription: Test = {
-  client: {
-    actions: [
-      { type: "invoke", id: "1", proc: "kv.set", payload: { k: "foo", v: 42 } },
-      { type: "invoke", id: "2", proc: "kv.watch", payload: { k: "foo" } },
-      { type: "wait", ms: SESSION_DISCONNECT_MS },
-      { type: "invoke", id: "3", proc: "kv.set", payload: { k: "foo", v: 43 } },
-    ],
-    expectedOutput: [
-      { id: "1", status: "ok", payload: 42 },
-      { id: "2", status: "ok", payload: 42 },
-      { id: "2", status: "ok", payload: 43 },
-      { id: "3", status: "ok", payload: 43 },
-    ],
+  clients: {
+    client: {
+      actions: [
+        {
+          type: "invoke",
+          id: "1",
+          proc: "kv.set",
+          payload: { k: "foo", v: 42 },
+        },
+        { type: "invoke", id: "2", proc: "kv.watch", payload: { k: "foo" } },
+        { type: "wait", ms: SESSION_DISCONNECT_MS },
+        {
+          type: "invoke",
+          id: "3",
+          proc: "kv.set",
+          payload: { k: "foo", v: 43 },
+        },
+      ],
+      expectedOutput: [
+        { id: "1", status: "ok", payload: 42 },
+        { id: "2", status: "ok", payload: 42 },
+        { id: "2", status: "ok", payload: 43 },
+        { id: "3", status: "ok", payload: 43 },
+      ],
+    },
   },
 };
 
 const KvMultipleLongSubscription: Test = {
-  client: {
-    actions: [
-      { type: "invoke", id: "1", proc: "kv.set", payload: { k: "foo", v: 42 } },
-      { type: "invoke", id: "2", proc: "kv.watch", payload: { k: "foo" } },
-      { type: "wait", ms: SESSION_DISCONNECT_MS },
-      { type: "invoke", id: "3", proc: "kv.set", payload: { k: "foo", v: 43 } },
-      { type: "invoke", id: "4", proc: "kv.watch", payload: { k: "foo" } },
-      { type: "wait", ms: SESSION_DISCONNECT_MS },
-      { type: "invoke", id: "5", proc: "kv.set", payload: { k: "foo", v: 44 } },
-    ],
-    expectedOutput: [
-      { id: "1", status: "ok", payload: 42 },
-      { id: "2", status: "ok", payload: 42 },
-      { id: "2", status: "ok", payload: 43 },
-      { id: "3", status: "ok", payload: 43 },
-      { id: "4", status: "ok", payload: 43 },
-      { id: "2", status: "ok", payload: 44 },
-      { id: "4", status: "ok", payload: 44 },
-      { id: "5", status: "ok", payload: 44 },
-    ],
+  clients: {
+    client: {
+      actions: [
+        {
+          type: "invoke",
+          id: "1",
+          proc: "kv.set",
+          payload: { k: "foo", v: 42 },
+        },
+        { type: "invoke", id: "2", proc: "kv.watch", payload: { k: "foo" } },
+        { type: "wait", ms: SESSION_DISCONNECT_MS },
+        {
+          type: "invoke",
+          id: "3",
+          proc: "kv.set",
+          payload: { k: "foo", v: 43 },
+        },
+        { type: "invoke", id: "4", proc: "kv.watch", payload: { k: "foo" } },
+        { type: "wait", ms: SESSION_DISCONNECT_MS },
+        {
+          type: "invoke",
+          id: "5",
+          proc: "kv.set",
+          payload: { k: "foo", v: 44 },
+        },
+      ],
+      expectedOutput: [
+        { id: "1", status: "ok", payload: 42 },
+        { id: "2", status: "ok", payload: 42 },
+        { id: "2", status: "ok", payload: 43 },
+        { id: "3", status: "ok", payload: 43 },
+        { id: "4", status: "ok", payload: 43 },
+        { id: "2", status: "ok", payload: 44 },
+        { id: "4", status: "ok", payload: 44 },
+        { id: "5", status: "ok", payload: 44 },
+      ],
+    },
   },
 };
 

--- a/tests/basic/upload.ts
+++ b/tests/basic/upload.ts
@@ -1,29 +1,31 @@
 import type { Test } from "../../src/actions";
 
 const UploadSendTest: Test = {
-  client: {
-    actions: [
-      { type: "invoke", id: "1", proc: "upload.send", init: {} },
-      {
-        type: "invoke",
-        id: "1",
-        proc: "upload.send",
-        payload: { part: "abc" },
-      },
-      {
-        type: "invoke",
-        id: "1",
-        proc: "upload.send",
-        payload: { part: "def" },
-      },
-      {
-        type: "invoke",
-        id: "1",
-        proc: "upload.send",
-        payload: { part: "EOF" },
-      },
-    ],
-    expectedOutput: [{ id: "1", status: "ok", payload: "abcdef" }],
+  clients: {
+    client: {
+      actions: [
+        { type: "invoke", id: "1", proc: "upload.send", init: {} },
+        {
+          type: "invoke",
+          id: "1",
+          proc: "upload.send",
+          payload: { part: "abc" },
+        },
+        {
+          type: "invoke",
+          id: "1",
+          proc: "upload.send",
+          payload: { part: "def" },
+        },
+        {
+          type: "invoke",
+          id: "1",
+          proc: "upload.send",
+          payload: { part: "EOF" },
+        },
+      ],
+      expectedOutput: [{ id: "1", status: "ok", payload: "abcdef" }],
+    },
   },
 };
 

--- a/tests/disconnect_notifs.ts
+++ b/tests/disconnect_notifs.ts
@@ -2,78 +2,110 @@ import type { Test } from "../src/actions";
 import { SESSION_DISCONNECT_MS } from "./constants";
 
 const RpcDisconnectNotifs: Test = {
-  client: {
-    actions: [
-      { type: "invoke", id: "1", proc: "kv.set", payload: { k: "foo", v: 42 } },
-      { type: "wait", ms: 500 },
-      { type: "disconnect_network" },
-      // invoking after disconnected should eventually tell us unexpected disconnect
-      { type: "invoke", id: "2", proc: "kv.set", payload: { k: "foo", v: 43 } },
-      { type: "wait", ms: SESSION_DISCONNECT_MS },
-    ],
-    expectedOutput: [
-      { id: "1", status: "ok", payload: 42 },
-      { id: "2", status: "err", payload: "UNEXPECTED_DISCONNECT" },
-    ],
+  flaky: true,
+  clients: {
+    client: {
+      actions: [
+        {
+          type: "invoke",
+          id: "1",
+          proc: "kv.set",
+          payload: { k: "foo", v: 42 },
+        },
+        { type: "wait", ms: 500 },
+        { type: "disconnect_network" },
+        // invoking after disconnected should eventually tell us unexpected disconnect
+        {
+          type: "invoke",
+          id: "2",
+          proc: "kv.set",
+          payload: { k: "foo", v: 43 },
+        },
+        { type: "wait", ms: SESSION_DISCONNECT_MS },
+      ],
+      expectedOutput: [
+        { id: "1", status: "ok", payload: 42 },
+        { id: "2", status: "err", payload: "UNEXPECTED_DISCONNECT" },
+      ],
+    },
   },
 };
 
 const SubscribeDisconnectNotifs: Test = {
-  client: {
-    actions: [
-      { type: "invoke", id: "1", proc: "kv.set", payload: { k: "foo", v: 42 } },
-      { type: "invoke", id: "2", proc: "kv.watch", payload: { k: "foo" } },
-      { type: "wait", ms: 500 },
-      { type: "disconnect_network" },
-      { type: "wait", ms: SESSION_DISCONNECT_MS },
-    ],
-    expectedOutput: [
-      { id: "1", status: "ok", payload: 42 },
-      { id: "2", status: "ok", payload: 42 },
-      { id: "2", status: "err", payload: "UNEXPECTED_DISCONNECT" },
-    ],
+  flaky: true,
+  clients: {
+    client: {
+      actions: [
+        {
+          type: "invoke",
+          id: "1",
+          proc: "kv.set",
+          payload: { k: "foo", v: 42 },
+        },
+        { type: "invoke", id: "2", proc: "kv.watch", payload: { k: "foo" } },
+        { type: "wait", ms: 500 },
+        { type: "disconnect_network" },
+        { type: "wait", ms: SESSION_DISCONNECT_MS },
+      ],
+      expectedOutput: [
+        { id: "1", status: "ok", payload: 42 },
+        { id: "2", status: "ok", payload: 42 },
+        { id: "2", status: "err", payload: "UNEXPECTED_DISCONNECT" },
+      ],
+    },
   },
 };
 
 const StreamDisconnectNotifs: Test = {
-  client: {
-    actions: [
-      { type: "invoke", id: "1", proc: "repeat.echo", init: {} },
-      { type: "invoke", id: "1", proc: "repeat.echo", payload: { s: "hello" } },
-      { type: "wait", ms: 500 },
-      { type: "disconnect_network" },
-      { type: "wait", ms: SESSION_DISCONNECT_MS },
-    ],
-    expectedOutput: [
-      { id: "1", status: "ok", payload: "hello" },
-      { id: "1", status: "err", payload: "UNEXPECTED_DISCONNECT" },
-    ],
+  flaky: true,
+  clients: {
+    client: {
+      actions: [
+        { type: "invoke", id: "1", proc: "repeat.echo", init: {} },
+        {
+          type: "invoke",
+          id: "1",
+          proc: "repeat.echo",
+          payload: { s: "hello" },
+        },
+        { type: "wait", ms: 500 },
+        { type: "disconnect_network" },
+        { type: "wait", ms: SESSION_DISCONNECT_MS },
+      ],
+      expectedOutput: [
+        { id: "1", status: "ok", payload: "hello" },
+        { id: "1", status: "err", payload: "UNEXPECTED_DISCONNECT" },
+      ],
+    },
   },
 };
 
 const UploadDisconnectNotifs: Test = {
-  client: {
-    actions: [
-      { type: "invoke", id: "1", proc: "upload.send", init: {} },
-      {
-        type: "invoke",
-        id: "1",
-        proc: "upload.send",
-        payload: { part: "abc" },
-      },
-      {
-        type: "invoke",
-        id: "1",
-        proc: "upload.send",
-        payload: { part: "def" },
-      },
-      { type: "wait", ms: 500 },
-      { type: "disconnect_network" },
-      { type: "wait", ms: SESSION_DISCONNECT_MS },
-    ],
-    expectedOutput: [
-      { id: "1", status: "err", payload: "UNEXPECTED_DISCONNECT" },
-    ],
+  flaky: true,
+  clients: {
+    client: {
+      actions: [
+        { type: "invoke", id: "1", proc: "upload.send", init: {} },
+        {
+          type: "invoke",
+          id: "1",
+          proc: "upload.send",
+          payload: { part: "abc" },
+        },
+        {
+          type: "invoke",
+          id: "1",
+          proc: "upload.send",
+          payload: { part: "def" },
+        },
+        { type: "wait", ms: 500 },
+        { type: "disconnect_network" },
+        { type: "wait", ms: SESSION_DISCONNECT_MS },
+      ],
+      expectedOutput: [
+        { id: "1", status: "err", payload: "UNEXPECTED_DISCONNECT" },
+      ],
+    },
   },
 };
 

--- a/tests/instance_mismatch.ts
+++ b/tests/instance_mismatch.ts
@@ -1,61 +1,66 @@
 import type { Test } from "../src/actions";
 
 const MismatchedClientInstanceDoesntGetResentStaleMessagesFromServer: Test = {
-  client: {
-    actions: [
-      { type: "invoke", id: "1", proc: "upload.send", init: {} },
-      {
-        type: "invoke",
-        id: "1",
-        proc: "upload.send",
-        payload: { part: "abc" },
-      },
-      { type: "restart_container" },
-      { type: "invoke", id: "1", proc: "upload.send", init: {} },
-      {
-        type: "invoke",
-        id: "1",
-        proc: "upload.send",
-        payload: { part: "def" },
-      },
-      {
-        type: "invoke",
-        id: "1",
-        proc: "upload.send",
-        payload: { part: "EOF" },
-      },
-    ],
-    expectedOutput: [{ id: "1", status: "ok", payload: "def" }],
+  clients: {
+    client: {
+      actions: [
+        { type: "invoke", id: "1", proc: "upload.send", init: {} },
+        {
+          type: "invoke",
+          id: "1",
+          proc: "upload.send",
+          payload: { part: "abc" },
+        },
+        { type: "restart_container" },
+        { type: "invoke", id: "1", proc: "upload.send", init: {} },
+        {
+          type: "invoke",
+          id: "1",
+          proc: "upload.send",
+          payload: { part: "def" },
+        },
+        {
+          type: "invoke",
+          id: "1",
+          proc: "upload.send",
+          payload: { part: "EOF" },
+        },
+      ],
+      expectedOutput: [{ id: "1", status: "ok", payload: "def" }],
+    },
   },
 };
 
 const MismatchedServerInstanceDoesntGetResentStaleMessagesFromClient: Test = {
-  client: {
-    actions: [
-      { type: "invoke", id: "1", proc: "upload.send", init: {} },
-      {
-        type: "invoke",
-        id: "1",
-        proc: "upload.send",
-        payload: { part: "abc" },
-      },
-      { type: "wait", ms: 3000 },
-      {
-        type: "invoke",
-        id: "1",
-        proc: "upload.send",
-        payload: { part: "def" },
-      },
-      {
-        type: "invoke",
-        id: "1",
-        proc: "upload.send",
-        payload: { part: "EOF" },
-      },
-    ],
-    expectedOutput: [
-      { id: "1", status: "err", payload: "UNEXPECTED_DISCONNECT" },
-    ],
+  flaky: true,
+  clients: {
+    client: {
+      actions: [
+        { type: "invoke", id: "1", proc: "upload.send", init: {} },
+        {
+          type: "invoke",
+          id: "1",
+          proc: "upload.send",
+          payload: { part: "abc" },
+        },
+        { type: "wait", ms: 3000 },
+        {
+          type: "invoke",
+          id: "1",
+          proc: "upload.send",
+          payload: { part: "def" },
+        },
+        {
+          type: "invoke",
+          id: "1",
+          proc: "upload.send",
+          payload: { part: "EOF" },
+        },
+      ],
+      expectedOutput: [
+        { id: "1", status: "err", payload: "UNEXPECTED_DISCONNECT" },
+      ],
+    },
   },
   server: {
     serverActions: [{ type: "wait", ms: 100 }, { type: "restart_container" }],

--- a/tests/interleaving.ts
+++ b/tests/interleaving.ts
@@ -1,43 +1,65 @@
 import type { Test } from "../src/actions";
 
 const ComplexInterleavingAllProcedures: Test = {
-  client: {
-    actions: [
-      { type: "invoke", id: "1", proc: "kv.set", payload: { k: "foo", v: 42 } },
-      { type: "invoke", id: "2", proc: "kv.watch", payload: { k: "foo" } },
-      { type: "invoke", id: "3", proc: "repeat.echo", init: {} },
-      { type: "invoke", id: "3", proc: "repeat.echo", payload: { s: "hello" } },
-      { type: "invoke", id: "4", proc: "upload.send", init: {} },
-      {
-        type: "invoke",
-        id: "4",
-        proc: "upload.send",
-        payload: { part: "abc" },
-      },
-      { type: "invoke", id: "3", proc: "repeat.echo", payload: { s: "world" } },
-      {
-        type: "invoke",
-        id: "4",
-        proc: "upload.send",
-        payload: { part: "def" },
-      },
-      { type: "invoke", id: "5", proc: "kv.set", payload: { k: "foo", v: 1 } },
-      {
-        type: "invoke",
-        id: "4",
-        proc: "upload.send",
-        payload: { part: "EOF" },
-      },
-    ],
-    expectedOutput: [
-      { id: "1", status: "ok", payload: 42 },
-      { id: "2", status: "ok", payload: 42 },
-      { id: "3", status: "ok", payload: "hello" },
-      { id: "3", status: "ok", payload: "world" },
-      { id: "2", status: "ok", payload: 1 },
-      { id: "5", status: "ok", payload: 1 },
-      { id: "4", status: "ok", payload: "abcdef" },
-    ],
+  clients: {
+    client: {
+      actions: [
+        {
+          type: "invoke",
+          id: "1",
+          proc: "kv.set",
+          payload: { k: "foo", v: 42 },
+        },
+        { type: "invoke", id: "2", proc: "kv.watch", payload: { k: "foo" } },
+        { type: "invoke", id: "3", proc: "repeat.echo", init: {} },
+        {
+          type: "invoke",
+          id: "3",
+          proc: "repeat.echo",
+          payload: { s: "hello" },
+        },
+        { type: "invoke", id: "4", proc: "upload.send", init: {} },
+        {
+          type: "invoke",
+          id: "4",
+          proc: "upload.send",
+          payload: { part: "abc" },
+        },
+        {
+          type: "invoke",
+          id: "3",
+          proc: "repeat.echo",
+          payload: { s: "world" },
+        },
+        {
+          type: "invoke",
+          id: "4",
+          proc: "upload.send",
+          payload: { part: "def" },
+        },
+        {
+          type: "invoke",
+          id: "5",
+          proc: "kv.set",
+          payload: { k: "foo", v: 1 },
+        },
+        {
+          type: "invoke",
+          id: "4",
+          proc: "upload.send",
+          payload: { part: "EOF" },
+        },
+      ],
+      expectedOutput: [
+        { id: "1", status: "ok", payload: 42 },
+        { id: "2", status: "ok", payload: 42 },
+        { id: "3", status: "ok", payload: "hello" },
+        { id: "3", status: "ok", payload: "world" },
+        { id: "2", status: "ok", payload: 1 },
+        { id: "5", status: "ok", payload: 1 },
+        { id: "4", status: "ok", payload: "abcdef" },
+      ],
+    },
   },
 };
 

--- a/tests/network.ts
+++ b/tests/network.ts
@@ -2,505 +2,796 @@ import type { Action, ExpectedOutputEntry, Test } from "../src/actions";
 import { WS_DISCONNECT_PERIOD_MS, SESSION_DISCONNECT_MS } from "./constants";
 
 const SurvivesTransientNetworkBlips: Test = {
-  client: {
-    actions: [
-      { type: "invoke", id: "1", proc: "kv.set", payload: { k: "foo", v: 42 } },
-      { type: "wait", ms: 500 },
-      { type: "disconnect_network" },
-      { type: "connect_network" },
-      { type: "invoke", id: "2", proc: "kv.set", payload: { k: "abc", v: 43 } },
-    ],
-    expectedOutput: [
-      { id: "1", status: "ok", payload: 42 },
-      { id: "2", status: "ok", payload: 43 },
-    ],
+  flaky: true,
+  clients: {
+    client: {
+      actions: [
+        {
+          type: "invoke",
+          id: "1",
+          proc: "kv.set",
+          payload: { k: "foo", v: 42 },
+        },
+        { type: "wait", ms: 500 },
+        { type: "disconnect_network" },
+        { type: "connect_network" },
+        {
+          type: "invoke",
+          id: "2",
+          proc: "kv.set",
+          payload: { k: "abc", v: 43 },
+        },
+      ],
+      expectedOutput: [
+        { id: "1", status: "ok", payload: 42 },
+        { id: "2", status: "ok", payload: 43 },
+      ],
+    },
   },
 };
 
 const ShortConnectionDisconnectTest: Test = {
-  client: {
-    actions: [
-      { type: "invoke", id: "1", proc: "kv.set", payload: { k: "foo", v: 42 } },
-      { type: "wait", ms: 500 },
-      { type: "disconnect_network" },
-      { type: "wait", ms: WS_DISCONNECT_PERIOD_MS },
-      { type: "connect_network" },
-      { type: "invoke", id: "2", proc: "kv.set", payload: { k: "foo", v: 43 } },
-    ],
-    expectedOutput: [
-      { id: "1", status: "ok", payload: 42 },
-      { id: "2", status: "ok", payload: 43 },
-    ],
+  clients: {
+    client: {
+      actions: [
+        {
+          type: "invoke",
+          id: "1",
+          proc: "kv.set",
+          payload: { k: "foo", v: 42 },
+        },
+        { type: "wait", ms: 500 },
+        { type: "disconnect_network" },
+        { type: "wait", ms: WS_DISCONNECT_PERIOD_MS },
+        { type: "connect_network" },
+        {
+          type: "invoke",
+          id: "2",
+          proc: "kv.set",
+          payload: { k: "foo", v: 43 },
+        },
+      ],
+      expectedOutput: [
+        { id: "1", status: "ok", payload: 42 },
+        { id: "2", status: "ok", payload: 43 },
+      ],
+    },
   },
 };
 
 const SessionDisconnectTest: Test = {
-  client: {
-    actions: [
-      { type: "invoke", id: "1", proc: "kv.set", payload: { k: "foo", v: 42 } },
-      { type: "wait", ms: 500 },
-      { type: "disconnect_network" },
-      { type: "wait", ms: SESSION_DISCONNECT_MS },
-      { type: "connect_network" },
-      { type: "invoke", id: "2", proc: "kv.set", payload: { k: "foo", v: 43 } },
-    ],
-    expectedOutput: [
-      { id: "1", status: "ok", payload: 42 },
-      { id: "2", status: "ok", payload: 43 },
-    ],
+  flaky: true,
+  clients: {
+    client: {
+      actions: [
+        {
+          type: "invoke",
+          id: "1",
+          proc: "kv.set",
+          payload: { k: "foo", v: 42 },
+        },
+        { type: "wait", ms: 500 },
+        { type: "disconnect_network" },
+        { type: "wait", ms: SESSION_DISCONNECT_MS },
+        { type: "connect_network" },
+        {
+          type: "invoke",
+          id: "2",
+          proc: "kv.set",
+          payload: { k: "foo", v: 43 },
+        },
+      ],
+      expectedOutput: [
+        { id: "1", status: "ok", payload: 42 },
+        { id: "2", status: "ok", payload: 43 },
+      ],
+    },
   },
 };
 
 const SurvivesLongSessionIdle: Test = {
-  client: {
-    actions: [
-      { type: "invoke", id: "1", proc: "kv.set", payload: { k: "foo", v: 42 } },
-      { type: "wait", ms: 10000 },
-      { type: "invoke", id: "2", proc: "kv.set", payload: { k: "abc", v: 43 } },
-    ],
-    expectedOutput: [
-      { id: "1", status: "ok", payload: 42 },
-      { id: "2", status: "ok", payload: 43 },
-    ],
+  clients: {
+    client: {
+      actions: [
+        {
+          type: "invoke",
+          id: "1",
+          proc: "kv.set",
+          payload: { k: "foo", v: 42 },
+        },
+        { type: "wait", ms: 10000 },
+        {
+          type: "invoke",
+          id: "2",
+          proc: "kv.set",
+          payload: { k: "abc", v: 43 },
+        },
+      ],
+      expectedOutput: [
+        { id: "1", status: "ok", payload: 42 },
+        { id: "2", status: "ok", payload: 43 },
+      ],
+    },
   },
 };
 
 const ShouldNotSendBufferAfterSessionDisconnect: Test = {
-  client: {
-    actions: [
-      { type: "invoke", id: "1", proc: "kv.set", payload: { k: "foo", v: 42 } },
-      { type: "invoke", id: "2", proc: "kv.watch", payload: { k: "foo" } },
-      { type: "wait", ms: 500 },
-      { type: "disconnect_network" },
-      { type: "invoke", id: "3", proc: "kv.set", payload: { k: "foo", v: 43 } },
-      { type: "wait", ms: SESSION_DISCONNECT_MS },
-      { type: "connect_network" },
-      { type: "invoke", id: "4", proc: "kv.watch", payload: { k: "foo" } },
-      { type: "invoke", id: "5", proc: "kv.set", payload: { k: "foo", v: 44 } },
-    ],
-    expectedOutput: [
-      { id: "1", status: "ok", payload: 42 },
-      { id: "2", status: "ok", payload: 42 },
-      { id: "2", status: "err", payload: "UNEXPECTED_DISCONNECT" },
-      { id: "3", status: "err", payload: "UNEXPECTED_DISCONNECT" },
-      { id: "4", status: "ok", payload: 42 }, // watch should return the current value (43 should not be buffered)
-      { id: "4", status: "ok", payload: 44 },
-      { id: "5", status: "ok", payload: 44 },
-    ],
+  flaky: true,
+  clients: {
+    client: {
+      actions: [
+        {
+          type: "invoke",
+          id: "1",
+          proc: "kv.set",
+          payload: { k: "foo", v: 42 },
+        },
+        { type: "invoke", id: "2", proc: "kv.watch", payload: { k: "foo" } },
+        { type: "wait", ms: 500 },
+        { type: "disconnect_network" },
+        {
+          type: "invoke",
+          id: "3",
+          proc: "kv.set",
+          payload: { k: "foo", v: 43 },
+        },
+        { type: "wait", ms: SESSION_DISCONNECT_MS },
+        { type: "connect_network" },
+        { type: "invoke", id: "4", proc: "kv.watch", payload: { k: "foo" } },
+        {
+          type: "invoke",
+          id: "5",
+          proc: "kv.set",
+          payload: { k: "foo", v: 44 },
+        },
+      ],
+      expectedOutput: [
+        { id: "1", status: "ok", payload: 42 },
+        { id: "2", status: "ok", payload: 42 },
+        { id: "2", status: "err", payload: "UNEXPECTED_DISCONNECT" },
+        { id: "3", status: "err", payload: "UNEXPECTED_DISCONNECT" },
+        { id: "4", status: "ok", payload: 42 }, // watch should return the current value (43 should not be buffered)
+        { id: "4", status: "ok", payload: 44 },
+        { id: "5", status: "ok", payload: 44 },
+      ],
+    },
   },
 };
 
 const BufferedMessagesShouldTakePrecedenceOverNewMessages: Test = {
-  client: {
-    actions: [
-      { type: "wait", ms: 500 },
-      { type: "disconnect_network" },
-      { type: "invoke", id: "1", proc: "repeat.echo", init: {} },
-      { type: "invoke", id: "1", proc: "repeat.echo", payload: { s: "hello" } },
-      { type: "connect_network" },
-      { type: "invoke", id: "1", proc: "repeat.echo", payload: { s: "world" } },
-    ],
-    expectedOutput: [
-      { id: "1", status: "ok", payload: "hello" },
-      { id: "1", status: "ok", payload: "world" },
-    ],
+  clients: {
+    client: {
+      actions: [
+        { type: "wait", ms: 500 },
+        { type: "disconnect_network" },
+        { type: "invoke", id: "1", proc: "repeat.echo", init: {} },
+        {
+          type: "invoke",
+          id: "1",
+          proc: "repeat.echo",
+          payload: { s: "hello" },
+        },
+        { type: "connect_network" },
+        {
+          type: "invoke",
+          id: "1",
+          proc: "repeat.echo",
+          payload: { s: "world" },
+        },
+      ],
+      expectedOutput: [
+        { id: "1", status: "ok", payload: "hello" },
+        { id: "1", status: "ok", payload: "world" },
+      ],
+    },
   },
 };
 
 const MessageOrderingPreservedDuringDisconnect: Test = {
-  client: {
-    actions: [
-      { type: "invoke", id: "1", proc: "kv.set", payload: { k: "foo", v: 42 } },
-      { type: "wait", ms: 500 },
-      { type: "disconnect_network" },
-      ...Array.from(
-        { length: 10 },
-        (_, i): Action => ({
+  clients: {
+    client: {
+      actions: [
+        {
           type: "invoke",
-          id: (i + 2).toString(),
+          id: "1",
           proc: "kv.set",
-          payload: { k: "foo", v: i },
-        }),
-      ),
-      { type: "wait", ms: WS_DISCONNECT_PERIOD_MS },
-      { type: "connect_network" },
-    ],
-    expectedOutput: [
-      { id: "1", status: "ok", payload: 42 },
-      ...Array.from(
-        { length: 10 },
-        (_, i): ExpectedOutputEntry => ({
-          id: (i + 2).toString(),
-          status: "ok",
-          payload: i,
-        }),
-      ),
-    ],
+          payload: { k: "foo", v: 42 },
+        },
+        { type: "wait", ms: 500 },
+        { type: "disconnect_network" },
+        ...Array.from(
+          { length: 10 },
+          (_, i): Action => ({
+            type: "invoke",
+            id: (i + 2).toString(),
+            proc: "kv.set",
+            payload: { k: "foo", v: i },
+          }),
+        ),
+        { type: "wait", ms: WS_DISCONNECT_PERIOD_MS },
+        { type: "connect_network" },
+      ],
+      expectedOutput: [
+        { id: "1", status: "ok", payload: 42 },
+        ...Array.from(
+          { length: 10 },
+          (_, i): ExpectedOutputEntry => ({
+            id: (i + 2).toString(),
+            status: "ok",
+            payload: i,
+          }),
+        ),
+      ],
+    },
   },
 };
 
 const BuffersWhileDisconnectedTest: Test = {
-  client: {
-    actions: [
-      { type: "invoke", id: "1", proc: "kv.set", payload: { k: "foo", v: 42 } },
-      { type: "disconnect_network" },
-      { type: "invoke", id: "2", proc: "kv.set", payload: { k: "foo", v: 43 } },
-      { type: "invoke", id: "3", proc: "kv.set", payload: { k: "abc", v: 1 } },
-      { type: "connect_network" },
-    ],
-    expectedOutput: [
-      { id: "1", status: "ok", payload: 42 },
-      { id: "2", status: "ok", payload: 43 },
-      { id: "3", status: "ok", payload: 1 },
-    ],
+  clients: {
+    client: {
+      actions: [
+        {
+          type: "invoke",
+          id: "1",
+          proc: "kv.set",
+          payload: { k: "foo", v: 42 },
+        },
+        { type: "disconnect_network" },
+        {
+          type: "invoke",
+          id: "2",
+          proc: "kv.set",
+          payload: { k: "foo", v: 43 },
+        },
+        {
+          type: "invoke",
+          id: "3",
+          proc: "kv.set",
+          payload: { k: "abc", v: 1 },
+        },
+        { type: "connect_network" },
+      ],
+      expectedOutput: [
+        { id: "1", status: "ok", payload: 42 },
+        { id: "2", status: "ok", payload: 43 },
+        { id: "3", status: "ok", payload: 1 },
+      ],
+    },
   },
 };
 
 const SubscriptionDisconnectTest: Test = {
-  client: {
-    actions: [
-      { type: "invoke", id: "1", proc: "kv.set", payload: { k: "foo", v: 42 } },
-      { type: "invoke", id: "2", proc: "kv.watch", payload: { k: "foo" } },
-      { type: "wait", ms: 800 },
-      { type: "disconnect_network" },
-      { type: "invoke", id: "3", proc: "kv.set", payload: { k: "abc", v: 1 } },
-      { type: "invoke", id: "4", proc: "kv.set", payload: { k: "foo", v: 43 } },
-    ],
-    expectedOutput: [
-      { id: "1", status: "ok", payload: 42 },
-      { id: "2", status: "ok", payload: 42 }, // watch should return the current value
-    ],
+  flaky: true,
+  clients: {
+    client: {
+      actions: [
+        {
+          type: "invoke",
+          id: "1",
+          proc: "kv.set",
+          payload: { k: "foo", v: 42 },
+        },
+        { type: "invoke", id: "2", proc: "kv.watch", payload: { k: "foo" } },
+        { type: "wait", ms: 800 },
+        { type: "disconnect_network" },
+        {
+          type: "invoke",
+          id: "3",
+          proc: "kv.set",
+          payload: { k: "abc", v: 1 },
+        },
+        {
+          type: "invoke",
+          id: "4",
+          proc: "kv.set",
+          payload: { k: "foo", v: 43 },
+        },
+      ],
+      expectedOutput: [
+        { id: "1", status: "ok", payload: 42 },
+        { id: "2", status: "ok", payload: 42 }, // watch should return the current value
+      ],
+    },
   },
 };
 
 const SubscriptionReconnectTest: Test = {
-  client: {
-    actions: [
-      { type: "invoke", id: "1", proc: "kv.set", payload: { k: "foo", v: 42 } },
-      { type: "invoke", id: "2", proc: "kv.watch", payload: { k: "foo" } },
-      { type: "disconnect_network" },
-      { type: "wait", ms: 800 },
-      { type: "invoke", id: "3", proc: "kv.set", payload: { k: "abc", v: 1 } },
-      { type: "connect_network" },
-      { type: "invoke", id: "4", proc: "kv.set", payload: { k: "foo", v: 43 } },
-    ],
-    expectedOutput: [
-      { id: "1", status: "ok", payload: 42 },
-      { id: "2", status: "ok", payload: 42 }, // watch should return the current value
-      { id: "3", status: "ok", payload: 1 },
-      { id: "2", status: "ok", payload: 43 },
-      { id: "4", status: "ok", payload: 43 },
-    ],
+  flaky: true,
+  clients: {
+    client: {
+      actions: [
+        {
+          type: "invoke",
+          id: "1",
+          proc: "kv.set",
+          payload: { k: "foo", v: 42 },
+        },
+        { type: "invoke", id: "2", proc: "kv.watch", payload: { k: "foo" } },
+        { type: "disconnect_network" },
+        { type: "wait", ms: 800 },
+        {
+          type: "invoke",
+          id: "3",
+          proc: "kv.set",
+          payload: { k: "abc", v: 1 },
+        },
+        { type: "connect_network" },
+        {
+          type: "invoke",
+          id: "4",
+          proc: "kv.set",
+          payload: { k: "foo", v: 43 },
+        },
+      ],
+      expectedOutput: [
+        { id: "1", status: "ok", payload: 42 },
+        { id: "2", status: "ok", payload: 42 }, // watch should return the current value
+        { id: "3", status: "ok", payload: 1 },
+        { id: "2", status: "ok", payload: 43 },
+        { id: "4", status: "ok", payload: 43 },
+      ],
+    },
   },
 };
 
 const TwoClientDisconnectTest: Test = {
-  client1: {
-    actions: [
-      { type: "invoke", id: "1", proc: "kv.set", payload: { k: "foo", v: 42 } },
-      { type: "invoke", id: "2", proc: "kv.watch", payload: { k: "foo" } },
-      { type: "wait", ms: 500 },
-      { type: "disconnect_network" },
-      { type: "invoke", id: "3", proc: "kv.set", payload: { k: "foo", v: 1 } },
-      { type: "wait", ms: 500 },
-      { type: "connect_network" },
-    ],
-    expectedOutput: [
-      { id: "1", status: "ok", payload: 42 },
-      { id: "2", status: "ok", payload: 42 },
-      { id: "2", status: "ok", payload: 46 },
-      { id: "2", status: "ok", payload: 1 },
-      { id: "3", status: "ok", payload: 1 },
-    ],
-  },
-  client2: {
-    actions: [
-      { type: "wait", ms: 800 },
-      { type: "invoke", id: "5", proc: "kv.watch", payload: { k: "foo" } },
-      { type: "invoke", id: "6", proc: "kv.set", payload: { k: "foo", v: 46 } },
-    ],
-    expectedOutput: [
-      { id: "5", status: "ok", payload: 42 },
-      { id: "5", status: "ok", payload: 46 },
-      { id: "6", status: "ok", payload: 46 },
-      { id: "5", status: "ok", payload: 1 },
-    ],
+  flaky: true,
+  clients: {
+    client1: {
+      actions: [
+        {
+          type: "invoke",
+          id: "1",
+          proc: "kv.set",
+          payload: { k: "foo", v: 42 },
+        },
+        { type: "invoke", id: "2", proc: "kv.watch", payload: { k: "foo" } },
+        { type: "wait", ms: 500 },
+        { type: "disconnect_network" },
+        {
+          type: "invoke",
+          id: "3",
+          proc: "kv.set",
+          payload: { k: "foo", v: 1 },
+        },
+        { type: "wait", ms: 500 },
+        { type: "connect_network" },
+      ],
+      expectedOutput: [
+        { id: "1", status: "ok", payload: 42 },
+        { id: "2", status: "ok", payload: 42 },
+        { id: "2", status: "ok", payload: 46 },
+        { id: "2", status: "ok", payload: 1 },
+        { id: "3", status: "ok", payload: 1 },
+      ],
+    },
+    client2: {
+      actions: [
+        { type: "wait", ms: 800 },
+        { type: "invoke", id: "5", proc: "kv.watch", payload: { k: "foo" } },
+        {
+          type: "invoke",
+          id: "6",
+          proc: "kv.set",
+          payload: { k: "foo", v: 46 },
+        },
+      ],
+      expectedOutput: [
+        { id: "5", status: "ok", payload: 42 },
+        { id: "5", status: "ok", payload: 46 },
+        { id: "6", status: "ok", payload: 46 },
+        { id: "5", status: "ok", payload: 1 },
+      ],
+    },
   },
 };
 
 const RepeatedConnectReconnectTest: Test = {
-  client: {
-    actions: [
-      { type: "invoke", id: "1", proc: "kv.set", payload: { k: "foo", v: 42 } },
-      { type: "invoke", id: "2", proc: "kv.set", payload: { k: "foo", v: 43 } },
-      { type: "invoke", id: "3", proc: "kv.set", payload: { k: "foo", v: 44 } },
-      { type: "disconnect_network" },
-      { type: "wait", ms: 500 },
-      { type: "connect_network" },
-      { type: "invoke", id: "4", proc: "kv.set", payload: { k: "foo", v: 45 } },
-      { type: "invoke", id: "5", proc: "kv.set", payload: { k: "foo", v: 46 } },
-      { type: "invoke", id: "6", proc: "kv.set", payload: { k: "foo", v: 47 } },
-      { type: "disconnect_network" },
-      { type: "wait", ms: 500 },
-      { type: "connect_network" },
-      { type: "invoke", id: "7", proc: "kv.set", payload: { k: "foo", v: 48 } },
-      { type: "invoke", id: "8", proc: "kv.set", payload: { k: "foo", v: 49 } },
-      { type: "invoke", id: "9", proc: "kv.set", payload: { k: "foo", v: 50 } },
-    ],
-    expectedOutput: [
-      { id: "1", status: "ok", payload: 42 },
-      { id: "2", status: "ok", payload: 43 },
-      { id: "3", status: "ok", payload: 44 },
-      { id: "4", status: "ok", payload: 45 },
-      { id: "5", status: "ok", payload: 46 },
-      { id: "6", status: "ok", payload: 47 },
-      { id: "7", status: "ok", payload: 48 },
-      { id: "8", status: "ok", payload: 49 },
-      { id: "9", status: "ok", payload: 50 },
-    ],
+  clients: {
+    client: {
+      actions: [
+        {
+          type: "invoke",
+          id: "1",
+          proc: "kv.set",
+          payload: { k: "foo", v: 42 },
+        },
+        {
+          type: "invoke",
+          id: "2",
+          proc: "kv.set",
+          payload: { k: "foo", v: 43 },
+        },
+        {
+          type: "invoke",
+          id: "3",
+          proc: "kv.set",
+          payload: { k: "foo", v: 44 },
+        },
+        { type: "disconnect_network" },
+        { type: "wait", ms: 500 },
+        { type: "connect_network" },
+        {
+          type: "invoke",
+          id: "4",
+          proc: "kv.set",
+          payload: { k: "foo", v: 45 },
+        },
+        {
+          type: "invoke",
+          id: "5",
+          proc: "kv.set",
+          payload: { k: "foo", v: 46 },
+        },
+        {
+          type: "invoke",
+          id: "6",
+          proc: "kv.set",
+          payload: { k: "foo", v: 47 },
+        },
+        { type: "disconnect_network" },
+        { type: "wait", ms: 500 },
+        { type: "connect_network" },
+        {
+          type: "invoke",
+          id: "7",
+          proc: "kv.set",
+          payload: { k: "foo", v: 48 },
+        },
+        {
+          type: "invoke",
+          id: "8",
+          proc: "kv.set",
+          payload: { k: "foo", v: 49 },
+        },
+        {
+          type: "invoke",
+          id: "9",
+          proc: "kv.set",
+          payload: { k: "foo", v: 50 },
+        },
+      ],
+      expectedOutput: [
+        { id: "1", status: "ok", payload: 42 },
+        { id: "2", status: "ok", payload: 43 },
+        { id: "3", status: "ok", payload: 44 },
+        { id: "4", status: "ok", payload: 45 },
+        { id: "5", status: "ok", payload: 46 },
+        { id: "6", status: "ok", payload: 47 },
+        { id: "7", status: "ok", payload: 48 },
+        { id: "8", status: "ok", payload: 49 },
+        { id: "9", status: "ok", payload: 50 },
+      ],
+    },
   },
 };
 
 const WatchDuringDisconnect: Test = {
-  client: {
-    actions: [
-      { type: "invoke", id: "1", proc: "kv.set", payload: { k: "foo", v: 42 } },
-      { type: "wait", ms: 500 },
-      { type: "disconnect_network" },
-      { type: "invoke", id: "2", proc: "kv.watch", payload: { k: "foo" } },
-      { type: "wait", ms: WS_DISCONNECT_PERIOD_MS },
-      { type: "connect_network" },
-      { type: "invoke", id: "3", proc: "kv.set", payload: { k: "foo", v: 43 } },
-    ],
-    expectedOutput: [
-      { id: "1", status: "ok", payload: 42 },
-      { id: "2", status: "ok", payload: 42 },
-      { id: "2", status: "ok", payload: 43 },
-      { id: "3", status: "ok", payload: 43 },
-    ],
+  clients: {
+    client: {
+      actions: [
+        {
+          type: "invoke",
+          id: "1",
+          proc: "kv.set",
+          payload: { k: "foo", v: 42 },
+        },
+        { type: "wait", ms: 500 },
+        { type: "disconnect_network" },
+        { type: "invoke", id: "2", proc: "kv.watch", payload: { k: "foo" } },
+        { type: "wait", ms: WS_DISCONNECT_PERIOD_MS },
+        { type: "connect_network" },
+        {
+          type: "invoke",
+          id: "3",
+          proc: "kv.set",
+          payload: { k: "foo", v: 43 },
+        },
+      ],
+      expectedOutput: [
+        { id: "1", status: "ok", payload: 42 },
+        { id: "2", status: "ok", payload: 42 },
+        { id: "2", status: "ok", payload: 43 },
+        { id: "3", status: "ok", payload: 43 },
+      ],
+    },
   },
 };
 
 const ShortDisconnectMultipleTimes: Test = {
-  client: {
-    actions: [
-      { type: "invoke", id: "1", proc: "kv.set", payload: { k: "foo", v: 42 } },
-      { type: "invoke", id: "2", proc: "kv.watch", payload: { k: "foo" } },
-      { type: "wait", ms: 500 },
-      { type: "disconnect_network" },
-      { type: "invoke", id: "3", proc: "kv.watch", payload: { k: "foo" } },
-      { type: "wait", ms: WS_DISCONNECT_PERIOD_MS },
-      { type: "connect_network" },
-      { type: "wait", ms: 500 },
-      { type: "disconnect_network" },
-      { type: "wait", ms: WS_DISCONNECT_PERIOD_MS },
-      { type: "connect_network" },
-      { type: "invoke", id: "4", proc: "kv.set", payload: { k: "foo", v: 43 } },
-    ],
-    expectedOutput: [
-      { id: "1", status: "ok", payload: 42 },
-      { id: "2", status: "ok", payload: 42 },
-      { id: "3", status: "ok", payload: 42 },
-      { id: "2", status: "ok", payload: 43 },
-      { id: "3", status: "ok", payload: 43 },
-      { id: "4", status: "ok", payload: 43 },
-    ],
+  flaky: true,
+  clients: {
+    client: {
+      actions: [
+        {
+          type: "invoke",
+          id: "1",
+          proc: "kv.set",
+          payload: { k: "foo", v: 42 },
+        },
+        { type: "invoke", id: "2", proc: "kv.watch", payload: { k: "foo" } },
+        { type: "wait", ms: 500 },
+        { type: "disconnect_network" },
+        { type: "invoke", id: "3", proc: "kv.watch", payload: { k: "foo" } },
+        { type: "wait", ms: WS_DISCONNECT_PERIOD_MS },
+        { type: "connect_network" },
+        { type: "wait", ms: 500 },
+        { type: "disconnect_network" },
+        { type: "wait", ms: WS_DISCONNECT_PERIOD_MS },
+        { type: "connect_network" },
+        {
+          type: "invoke",
+          id: "4",
+          proc: "kv.set",
+          payload: { k: "foo", v: 43 },
+        },
+      ],
+      expectedOutput: [
+        { id: "1", status: "ok", payload: 42 },
+        { id: "2", status: "ok", payload: 42 },
+        { id: "3", status: "ok", payload: 42 },
+        { id: "2", status: "ok", payload: 43 },
+        { id: "3", status: "ok", payload: 43 },
+        { id: "4", status: "ok", payload: 43 },
+      ],
+    },
   },
 };
 
 const DisconnectMultipleTimes: Test = {
-  client: {
-    actions: [
-      { type: "invoke", id: "1", proc: "kv.set", payload: { k: "foo", v: 42 } },
-      { type: "wait", ms: 500 },
-      { type: "disconnect_network" },
-      { type: "wait", ms: SESSION_DISCONNECT_MS },
-      { type: "connect_network" },
-      { type: "invoke", id: "2", proc: "kv.set", payload: { k: "foo", v: 43 } },
-      { type: "wait", ms: 3000 }, // give some buffer for budget to restore
-      { type: "disconnect_network" },
-      { type: "wait", ms: SESSION_DISCONNECT_MS },
-      { type: "connect_network" },
-      { type: "invoke", id: "3", proc: "kv.set", payload: { k: "foo", v: 44 } },
-    ],
-    expectedOutput: [
-      { id: "1", status: "ok", payload: 42 },
-      // TODO: what should be the behavior here?
-      { id: "2", status: "ok", payload: 43 },
-      { id: "3", status: "ok", payload: 44 },
-    ],
+  flaky: true,
+  clients: {
+    client: {
+      actions: [
+        {
+          type: "invoke",
+          id: "1",
+          proc: "kv.set",
+          payload: { k: "foo", v: 42 },
+        },
+        { type: "wait", ms: 500 },
+        { type: "disconnect_network" },
+        { type: "wait", ms: SESSION_DISCONNECT_MS },
+        { type: "connect_network" },
+        {
+          type: "invoke",
+          id: "2",
+          proc: "kv.set",
+          payload: { k: "foo", v: 43 },
+        },
+        { type: "wait", ms: 3000 }, // give some buffer for budget to restore
+        { type: "disconnect_network" },
+        { type: "wait", ms: SESSION_DISCONNECT_MS },
+        { type: "connect_network" },
+        {
+          type: "invoke",
+          id: "3",
+          proc: "kv.set",
+          payload: { k: "foo", v: 44 },
+        },
+      ],
+      expectedOutput: [
+        { id: "1", status: "ok", payload: 42 },
+        // TODO: what should be the behavior here?
+        { id: "2", status: "ok", payload: 43 },
+        { id: "3", status: "ok", payload: 44 },
+      ],
+    },
   },
 };
 
 const ComplexSituation: Test = {
-  client1: {
-    actions: [
-      { type: "invoke", id: "1", proc: "kv.set", payload: { k: "foo", v: 42 } },
-      { type: "wait", ms: SESSION_DISCONNECT_MS },
-      { type: "invoke", id: "2", proc: "kv.watch", payload: { k: "foo" } },
-      { type: "invoke", id: "3", proc: "kv.set", payload: { k: "foo", v: 43 } },
-      { type: "wait", ms: WS_DISCONNECT_PERIOD_MS },
-      { type: "invoke", id: "4", proc: "kv.watch", payload: { k: "foo" } },
-      { type: "invoke", id: "5", proc: "kv.set", payload: { k: "foo", v: 44 } },
-      { type: "wait", ms: SESSION_DISCONNECT_MS },
-      { type: "invoke", id: "6", proc: "kv.watch", payload: { k: "foo" } },
-      { type: "invoke", id: "7", proc: "kv.set", payload: { k: "foo", v: 45 } },
-      { type: "wait", ms: 500 },
-      { type: "disconnect_network" },
-      { type: "wait", ms: SESSION_DISCONNECT_MS },
-      { type: "connect_network" },
-      {
-        type: "invoke",
-        id: "11",
-        proc: "kv.set",
-        payload: { k: "foo", v: 42 },
-      },
-      { type: "wait", ms: SESSION_DISCONNECT_MS },
-      { type: "invoke", id: "12", proc: "kv.watch", payload: { k: "foo" } },
-      {
-        type: "invoke",
-        id: "13",
-        proc: "kv.set",
-        payload: { k: "foo", v: 43 },
-      },
-      { type: "disconnect_network" },
-      { type: "wait", ms: WS_DISCONNECT_PERIOD_MS },
-      { type: "connect_network" },
-      { type: "invoke", id: "14", proc: "kv.watch", payload: { k: "foo" } },
-      {
-        type: "invoke",
-        id: "15",
-        proc: "kv.set",
-        payload: { k: "foo", v: 44 },
-      },
-      { type: "wait", ms: SESSION_DISCONNECT_MS },
-      { type: "invoke", id: "16", proc: "kv.watch", payload: { k: "foo" } },
-      {
-        type: "invoke",
-        id: "17",
-        proc: "kv.set",
-        payload: { k: "foo", v: 45 },
-      },
-      { type: "wait", ms: 500 },
-    ],
+  flaky: true,
+  clients: {
+    client1: {
+      actions: [
+        {
+          type: "invoke",
+          id: "1",
+          proc: "kv.set",
+          payload: { k: "foo", v: 42 },
+        },
+        { type: "wait", ms: SESSION_DISCONNECT_MS },
+        { type: "invoke", id: "2", proc: "kv.watch", payload: { k: "foo" } },
+        {
+          type: "invoke",
+          id: "3",
+          proc: "kv.set",
+          payload: { k: "foo", v: 43 },
+        },
+        { type: "wait", ms: WS_DISCONNECT_PERIOD_MS },
+        { type: "invoke", id: "4", proc: "kv.watch", payload: { k: "foo" } },
+        {
+          type: "invoke",
+          id: "5",
+          proc: "kv.set",
+          payload: { k: "foo", v: 44 },
+        },
+        { type: "wait", ms: SESSION_DISCONNECT_MS },
+        { type: "invoke", id: "6", proc: "kv.watch", payload: { k: "foo" } },
+        {
+          type: "invoke",
+          id: "7",
+          proc: "kv.set",
+          payload: { k: "foo", v: 45 },
+        },
+        { type: "wait", ms: 500 },
+        { type: "disconnect_network" },
+        { type: "wait", ms: SESSION_DISCONNECT_MS },
+        { type: "connect_network" },
+        {
+          type: "invoke",
+          id: "11",
+          proc: "kv.set",
+          payload: { k: "foo", v: 42 },
+        },
+        { type: "wait", ms: SESSION_DISCONNECT_MS },
+        { type: "invoke", id: "12", proc: "kv.watch", payload: { k: "foo" } },
+        {
+          type: "invoke",
+          id: "13",
+          proc: "kv.set",
+          payload: { k: "foo", v: 43 },
+        },
+        { type: "disconnect_network" },
+        { type: "wait", ms: WS_DISCONNECT_PERIOD_MS },
+        { type: "connect_network" },
+        { type: "invoke", id: "14", proc: "kv.watch", payload: { k: "foo" } },
+        {
+          type: "invoke",
+          id: "15",
+          proc: "kv.set",
+          payload: { k: "foo", v: 44 },
+        },
+        { type: "wait", ms: SESSION_DISCONNECT_MS },
+        { type: "invoke", id: "16", proc: "kv.watch", payload: { k: "foo" } },
+        {
+          type: "invoke",
+          id: "17",
+          proc: "kv.set",
+          payload: { k: "foo", v: 45 },
+        },
+        { type: "wait", ms: 500 },
+      ],
 
-    expectedOutput: [
-      { id: "1", status: "ok", payload: 42 },
-      { id: "2", status: "ok", payload: 42 },
-      { id: "2", status: "ok", payload: 43 },
-      { id: "3", status: "ok", payload: 43 },
-      { id: "4", status: "ok", payload: 43 },
-      { id: "2", status: "ok", payload: 44 },
-      { id: "4", status: "ok", payload: 44 },
-      { id: "5", status: "ok", payload: 44 },
-      { id: "6", status: "ok", payload: 44 },
-      { id: "2", status: "ok", payload: 45 },
-      { id: "4", status: "ok", payload: 45 },
-      { id: "6", status: "ok", payload: 45 },
-      { id: "7", status: "ok", payload: 45 },
+      expectedOutput: [
+        { id: "1", status: "ok", payload: 42 },
+        { id: "2", status: "ok", payload: 42 },
+        { id: "2", status: "ok", payload: 43 },
+        { id: "3", status: "ok", payload: 43 },
+        { id: "4", status: "ok", payload: 43 },
+        { id: "2", status: "ok", payload: 44 },
+        { id: "4", status: "ok", payload: 44 },
+        { id: "5", status: "ok", payload: 44 },
+        { id: "6", status: "ok", payload: 44 },
+        { id: "2", status: "ok", payload: 45 },
+        { id: "4", status: "ok", payload: 45 },
+        { id: "6", status: "ok", payload: 45 },
+        { id: "7", status: "ok", payload: 45 },
 
-      { id: "2", status: "err", payload: "UNEXPECTED_DISCONNECT" },
-      { id: "4", status: "err", payload: "UNEXPECTED_DISCONNECT" },
-      { id: "6", status: "err", payload: "UNEXPECTED_DISCONNECT" },
+        { id: "2", status: "err", payload: "UNEXPECTED_DISCONNECT" },
+        { id: "4", status: "err", payload: "UNEXPECTED_DISCONNECT" },
+        { id: "6", status: "err", payload: "UNEXPECTED_DISCONNECT" },
 
-      { id: "11", status: "ok", payload: 42 },
-      { id: "12", status: "ok", payload: 42 },
-      { id: "12", status: "ok", payload: 43 },
-      { id: "13", status: "ok", payload: 43 },
-      { id: "14", status: "ok", payload: 43 },
-      { id: "12", status: "ok", payload: 44 },
-      { id: "14", status: "ok", payload: 44 },
-      { id: "15", status: "ok", payload: 44 },
-      { id: "16", status: "ok", payload: 44 },
-      { id: "12", status: "ok", payload: 45 },
-      { id: "14", status: "ok", payload: 45 },
-      { id: "16", status: "ok", payload: 45 },
-      { id: "17", status: "ok", payload: 45 },
-    ],
-  },
+        { id: "11", status: "ok", payload: 42 },
+        { id: "12", status: "ok", payload: 42 },
+        { id: "12", status: "ok", payload: 43 },
+        { id: "13", status: "ok", payload: 43 },
+        { id: "14", status: "ok", payload: 43 },
+        { id: "12", status: "ok", payload: 44 },
+        { id: "14", status: "ok", payload: 44 },
+        { id: "15", status: "ok", payload: 44 },
+        { id: "16", status: "ok", payload: 44 },
+        { id: "12", status: "ok", payload: 45 },
+        { id: "14", status: "ok", payload: 45 },
+        { id: "16", status: "ok", payload: 45 },
+        { id: "17", status: "ok", payload: 45 },
+      ],
+    },
 
-  client2: {
-    actions: [
-      { type: "invoke", id: "1", proc: "kv.set", payload: { k: "bar", v: 12 } },
-      { type: "wait", ms: SESSION_DISCONNECT_MS },
-      { type: "invoke", id: "2", proc: "kv.watch", payload: { k: "bar" } },
-      { type: "invoke", id: "3", proc: "kv.set", payload: { k: "bar", v: 13 } },
-      { type: "wait", ms: WS_DISCONNECT_PERIOD_MS },
-      { type: "invoke", id: "4", proc: "kv.watch", payload: { k: "bar" } },
-      { type: "invoke", id: "5", proc: "kv.set", payload: { k: "bar", v: 14 } },
-      { type: "invoke", id: "6", proc: "kv.watch", payload: { k: "bar" } },
-      { type: "invoke", id: "7", proc: "kv.set", payload: { k: "bar", v: 15 } },
-      { type: "wait", ms: 500 },
-      { type: "disconnect_network" },
-      { type: "wait", ms: SESSION_DISCONNECT_MS },
-      { type: "connect_network" },
-      {
-        type: "invoke",
-        id: "11",
-        proc: "kv.set",
-        payload: { k: "bar", v: 12 },
-      },
-      { type: "wait", ms: SESSION_DISCONNECT_MS },
-      { type: "invoke", id: "12", proc: "kv.watch", payload: { k: "bar" } },
-      {
-        type: "invoke",
-        id: "13",
-        proc: "kv.set",
-        payload: { k: "bar", v: 13 },
-      },
-      { type: "disconnect_network" },
-      { type: "wait", ms: WS_DISCONNECT_PERIOD_MS },
-      { type: "connect_network" },
-      { type: "invoke", id: "14", proc: "kv.watch", payload: { k: "bar" } },
-      {
-        type: "invoke",
-        id: "15",
-        proc: "kv.set",
-        payload: { k: "bar", v: 14 },
-      },
-      { type: "wait", ms: SESSION_DISCONNECT_MS },
-      { type: "invoke", id: "16", proc: "kv.watch", payload: { k: "bar" } },
-      {
-        type: "invoke",
-        id: "17",
-        proc: "kv.set",
-        payload: { k: "bar", v: 15 },
-      },
-      { type: "wait", ms: 500 },
-    ],
-    expectedOutput: [
-      { id: "1", status: "ok", payload: 12 },
-      { id: "2", status: "ok", payload: 12 },
-      { id: "2", status: "ok", payload: 13 },
-      { id: "3", status: "ok", payload: 13 },
-      { id: "4", status: "ok", payload: 13 },
-      { id: "2", status: "ok", payload: 14 },
-      { id: "4", status: "ok", payload: 14 },
-      { id: "5", status: "ok", payload: 14 },
-      { id: "6", status: "ok", payload: 14 },
-      { id: "2", status: "ok", payload: 15 },
-      { id: "4", status: "ok", payload: 15 },
-      { id: "6", status: "ok", payload: 15 },
-      { id: "7", status: "ok", payload: 15 },
+    client2: {
+      actions: [
+        {
+          type: "invoke",
+          id: "1",
+          proc: "kv.set",
+          payload: { k: "bar", v: 12 },
+        },
+        { type: "wait", ms: SESSION_DISCONNECT_MS },
+        { type: "invoke", id: "2", proc: "kv.watch", payload: { k: "bar" } },
+        {
+          type: "invoke",
+          id: "3",
+          proc: "kv.set",
+          payload: { k: "bar", v: 13 },
+        },
+        { type: "wait", ms: WS_DISCONNECT_PERIOD_MS },
+        { type: "invoke", id: "4", proc: "kv.watch", payload: { k: "bar" } },
+        {
+          type: "invoke",
+          id: "5",
+          proc: "kv.set",
+          payload: { k: "bar", v: 14 },
+        },
+        { type: "invoke", id: "6", proc: "kv.watch", payload: { k: "bar" } },
+        {
+          type: "invoke",
+          id: "7",
+          proc: "kv.set",
+          payload: { k: "bar", v: 15 },
+        },
+        { type: "wait", ms: 500 },
+        { type: "disconnect_network" },
+        { type: "wait", ms: SESSION_DISCONNECT_MS },
+        { type: "connect_network" },
+        {
+          type: "invoke",
+          id: "11",
+          proc: "kv.set",
+          payload: { k: "bar", v: 12 },
+        },
+        { type: "wait", ms: SESSION_DISCONNECT_MS },
+        { type: "invoke", id: "12", proc: "kv.watch", payload: { k: "bar" } },
+        {
+          type: "invoke",
+          id: "13",
+          proc: "kv.set",
+          payload: { k: "bar", v: 13 },
+        },
+        { type: "disconnect_network" },
+        { type: "wait", ms: WS_DISCONNECT_PERIOD_MS },
+        { type: "connect_network" },
+        { type: "invoke", id: "14", proc: "kv.watch", payload: { k: "bar" } },
+        {
+          type: "invoke",
+          id: "15",
+          proc: "kv.set",
+          payload: { k: "bar", v: 14 },
+        },
+        { type: "wait", ms: SESSION_DISCONNECT_MS },
+        { type: "invoke", id: "16", proc: "kv.watch", payload: { k: "bar" } },
+        {
+          type: "invoke",
+          id: "17",
+          proc: "kv.set",
+          payload: { k: "bar", v: 15 },
+        },
+        { type: "wait", ms: 500 },
+      ],
+      expectedOutput: [
+        { id: "1", status: "ok", payload: 12 },
+        { id: "2", status: "ok", payload: 12 },
+        { id: "2", status: "ok", payload: 13 },
+        { id: "3", status: "ok", payload: 13 },
+        { id: "4", status: "ok", payload: 13 },
+        { id: "2", status: "ok", payload: 14 },
+        { id: "4", status: "ok", payload: 14 },
+        { id: "5", status: "ok", payload: 14 },
+        { id: "6", status: "ok", payload: 14 },
+        { id: "2", status: "ok", payload: 15 },
+        { id: "4", status: "ok", payload: 15 },
+        { id: "6", status: "ok", payload: 15 },
+        { id: "7", status: "ok", payload: 15 },
 
-      { id: "2", status: "err", payload: "UNEXPECTED_DISCONNECT" },
-      { id: "4", status: "err", payload: "UNEXPECTED_DISCONNECT" },
-      { id: "6", status: "err", payload: "UNEXPECTED_DISCONNECT" },
+        { id: "2", status: "err", payload: "UNEXPECTED_DISCONNECT" },
+        { id: "4", status: "err", payload: "UNEXPECTED_DISCONNECT" },
+        { id: "6", status: "err", payload: "UNEXPECTED_DISCONNECT" },
 
-      { id: "11", status: "ok", payload: 12 },
-      { id: "12", status: "ok", payload: 12 },
-      { id: "12", status: "ok", payload: 13 },
-      { id: "13", status: "ok", payload: 13 },
-      { id: "14", status: "ok", payload: 13 },
-      { id: "12", status: "ok", payload: 14 },
-      { id: "14", status: "ok", payload: 14 },
-      { id: "15", status: "ok", payload: 14 },
-      { id: "16", status: "ok", payload: 14 },
-      { id: "12", status: "ok", payload: 15 },
-      { id: "14", status: "ok", payload: 15 },
-      { id: "16", status: "ok", payload: 15 },
-      { id: "17", status: "ok", payload: 15 },
-    ],
+        { id: "11", status: "ok", payload: 12 },
+        { id: "12", status: "ok", payload: 12 },
+        { id: "12", status: "ok", payload: 13 },
+        { id: "13", status: "ok", payload: 13 },
+        { id: "14", status: "ok", payload: 13 },
+        { id: "12", status: "ok", payload: 14 },
+        { id: "14", status: "ok", payload: 14 },
+        { id: "15", status: "ok", payload: 14 },
+        { id: "16", status: "ok", payload: 14 },
+        { id: "12", status: "ok", payload: 15 },
+        { id: "14", status: "ok", payload: 15 },
+        { id: "16", status: "ok", payload: 15 },
+        { id: "17", status: "ok", payload: 15 },
+      ],
+    },
   },
 };
 

--- a/tests/volume.ts
+++ b/tests/volume.ts
@@ -2,47 +2,53 @@ import type { Action, Test } from "../src/actions";
 
 const MANY = 5000;
 const ManyRpcs: Test = {
-  client: {
-    actions: [
-      ...Array.from(
-        { length: MANY },
-        (_, i): Action => ({
-          type: "invoke",
-          id: (i + 1).toString(),
-          proc: "kv.set",
-          payload: { k: "foo", v: i },
-        }),
-      ),
-      { type: "wait", ms: 3000 },
-    ],
-    expectedOutput: Array.from({ length: MANY }, (_, i) => ({
-      id: (i + 1).toString(),
-      status: "ok",
-      payload: i,
-    })),
+  flaky: true,
+  clients: {
+    client: {
+      actions: [
+        ...Array.from(
+          { length: MANY },
+          (_, i): Action => ({
+            type: "invoke",
+            id: (i + 1).toString(),
+            proc: "kv.set",
+            payload: { k: "foo", v: i },
+          }),
+        ),
+        { type: "wait", ms: 3000 },
+      ],
+      expectedOutput: Array.from({ length: MANY }, (_, i) => ({
+        id: (i + 1).toString(),
+        status: "ok",
+        payload: i,
+      })),
+    },
   },
 };
 
 const ManyStreams: Test = {
-  client: {
-    actions: [
-      { type: "invoke", id: "1", proc: "repeat.echo", init: {} },
-      ...Array.from(
-        { length: MANY },
-        (_, i): Action => ({
-          type: "invoke",
-          id: "1",
-          proc: "repeat.echo",
-          payload: { s: i.toString() },
-        }),
-      ),
-      { type: "wait", ms: 2000 },
-    ],
-    expectedOutput: Array.from({ length: MANY }, (_, i) => ({
-      id: "1",
-      status: "ok",
-      payload: i.toString(),
-    })),
+  flaky: true,
+  clients: {
+    client: {
+      actions: [
+        { type: "invoke", id: "1", proc: "repeat.echo", init: {} },
+        ...Array.from(
+          { length: MANY },
+          (_, i): Action => ({
+            type: "invoke",
+            id: "1",
+            proc: "repeat.echo",
+            payload: { s: i.toString() },
+          }),
+        ),
+        { type: "wait", ms: 2000 },
+      ],
+      expectedOutput: Array.from({ length: MANY }, (_, i) => ({
+        id: "1",
+        status: "ok",
+        payload: i.toString(),
+      })),
+    },
   },
 };
 


### PR DESCRIPTION
We have a few tests in the three configurations that we care about in production that are flaking a lot (or failing consistently).

This change allows marking them as flaky in the tests, and marks them as flaky.

_Definitely_ review this change with [whitespace turned off](https://github.com/replit/river-babel/pull/26/files?diff=split&w=1).