### PR TITLE
Better distinguish between server and client actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,10 @@ name: Run Tests
 on:
   pull_request:
     branches:
-      - master
+      - main
   push:
     branches:
-      - master
+      - main
 
 jobs:
   format:

--- a/index.ts
+++ b/index.ts
@@ -5,14 +5,14 @@ import { hideBin } from "yargs/helpers";
 import {
   type Test,
   serializeExpectedOutputEntry,
-  type Action,
-  type InvokeActions,
+  type ServerAction,
 } from "./src/actions";
 import {
   buildImage,
   cleanup,
   setupNetwork,
-  applyAction,
+  applyActionClient,
+  applyActionServer,
   setupContainer,
   type ClientContainer,
 } from "./src/docker";
@@ -134,8 +134,7 @@ async function runSuite(
       "server",
     );
 
-    let serverActions: Exclude<Action, InvokeActions>[] =
-      test.server?.serverActions ?? [];
+    let serverActions: ServerAction[] = test.server?.serverActions ?? [];
     const containers: Record<string, ClientContainer> = {};
     for (const [clientName, testEntry] of Object.entries(test.clients)) {
       // client case
@@ -158,12 +157,12 @@ async function runSuite(
     await Promise.all([
       (async () => {
         for (const action of serverActions) {
-          await applyAction(network, serverContainer, action);
+          await applyActionServer(network, serverContainer, action);
         }
       })(),
       ...Object.entries(containers).map(async ([_clientName, client]) => {
         for (const action of client.actions) {
-          await applyAction(network, client, action);
+          await applyActionClient(network, client, action);
         }
       }),
     ]);

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1,8 +1,7 @@
 // driver actions for each container
-export type Action =
-  | InvokeActions
+export type CommonAction =
   | {
-      type: "wait";
+      type: "sleep";
       ms: number;
     }
   | {
@@ -21,7 +20,11 @@ export type Action =
       type: "unpause_container";
     };
 
-export type InvokeActions =
+export type ClientAction = CommonAction | InvokeAction;
+
+export type ServerAction = CommonAction;
+
+export type InvokeAction =
   | {
       type: "invoke";
       id: string;
@@ -79,7 +82,7 @@ export type InvokeActions =
       payload: { part: string };
     };
 
-export function serializeInvokeAction(action: InvokeActions) {
+export function serializeInvokeAction(action: InvokeAction) {
   let payload: string = "";
   if (action.proc === "kv.set") {
     payload = `${action.payload.k} ${action.payload.v}`;
@@ -123,12 +126,12 @@ export type Test = {
   clients: Record<
     string,
     {
-      actions: Action[];
+      actions: ClientAction[];
       expectedOutput: ExpectedOutputEntry[];
     }
   >;
   server?: {
-    serverActions: Exclude<Action, InvokeActions>[];
+    serverActions: ServerAction[];
   };
   flaky?: boolean;
 };

--- a/tests/basic/kv.ts
+++ b/tests/basic/kv.ts
@@ -80,6 +80,7 @@ const KvSubscribeErrorTest: Test = {
 };
 
 const KvSubscribeMultipleTest: Test = {
+  flaky: true,
   clients: {
     client1: {
       actions: [
@@ -113,7 +114,7 @@ const KvSubscribeMultipleTest: Test = {
     },
     client2: {
       actions: [
-        { type: "wait", ms: 800 },
+        { type: "sleep", ms: 800 },
         { type: "invoke", id: "a", proc: "kv.watch", payload: { k: "foo" } },
         {
           type: "invoke",
@@ -145,7 +146,7 @@ const KvLongSubscription: Test = {
           payload: { k: "foo", v: 42 },
         },
         { type: "invoke", id: "2", proc: "kv.watch", payload: { k: "foo" } },
-        { type: "wait", ms: SESSION_DISCONNECT_MS },
+        { type: "sleep", ms: SESSION_DISCONNECT_MS },
         {
           type: "invoke",
           id: "3",
@@ -174,7 +175,7 @@ const KvMultipleLongSubscription: Test = {
           payload: { k: "foo", v: 42 },
         },
         { type: "invoke", id: "2", proc: "kv.watch", payload: { k: "foo" } },
-        { type: "wait", ms: SESSION_DISCONNECT_MS },
+        { type: "sleep", ms: SESSION_DISCONNECT_MS },
         {
           type: "invoke",
           id: "3",
@@ -182,7 +183,7 @@ const KvMultipleLongSubscription: Test = {
           payload: { k: "foo", v: 43 },
         },
         { type: "invoke", id: "4", proc: "kv.watch", payload: { k: "foo" } },
-        { type: "wait", ms: SESSION_DISCONNECT_MS },
+        { type: "sleep", ms: SESSION_DISCONNECT_MS },
         {
           type: "invoke",
           id: "5",

--- a/tests/disconnect_notifs.ts
+++ b/tests/disconnect_notifs.ts
@@ -12,7 +12,7 @@ const RpcDisconnectNotifs: Test = {
           proc: "kv.set",
           payload: { k: "foo", v: 42 },
         },
-        { type: "wait", ms: 500 },
+        { type: "sleep", ms: 500 },
         { type: "disconnect_network" },
         // invoking after disconnected should eventually tell us unexpected disconnect
         {
@@ -21,7 +21,7 @@ const RpcDisconnectNotifs: Test = {
           proc: "kv.set",
           payload: { k: "foo", v: 43 },
         },
-        { type: "wait", ms: SESSION_DISCONNECT_MS },
+        { type: "sleep", ms: SESSION_DISCONNECT_MS },
       ],
       expectedOutput: [
         { id: "1", status: "ok", payload: 42 },
@@ -43,9 +43,9 @@ const SubscribeDisconnectNotifs: Test = {
           payload: { k: "foo", v: 42 },
         },
         { type: "invoke", id: "2", proc: "kv.watch", payload: { k: "foo" } },
-        { type: "wait", ms: 500 },
+        { type: "sleep", ms: 500 },
         { type: "disconnect_network" },
-        { type: "wait", ms: SESSION_DISCONNECT_MS },
+        { type: "sleep", ms: SESSION_DISCONNECT_MS },
       ],
       expectedOutput: [
         { id: "1", status: "ok", payload: 42 },
@@ -68,9 +68,9 @@ const StreamDisconnectNotifs: Test = {
           proc: "repeat.echo",
           payload: { s: "hello" },
         },
-        { type: "wait", ms: 500 },
+        { type: "sleep", ms: 500 },
         { type: "disconnect_network" },
-        { type: "wait", ms: SESSION_DISCONNECT_MS },
+        { type: "sleep", ms: SESSION_DISCONNECT_MS },
       ],
       expectedOutput: [
         { id: "1", status: "ok", payload: "hello" },
@@ -98,9 +98,9 @@ const UploadDisconnectNotifs: Test = {
           proc: "upload.send",
           payload: { part: "def" },
         },
-        { type: "wait", ms: 500 },
+        { type: "sleep", ms: 500 },
         { type: "disconnect_network" },
-        { type: "wait", ms: SESSION_DISCONNECT_MS },
+        { type: "sleep", ms: SESSION_DISCONNECT_MS },
       ],
       expectedOutput: [
         { id: "1", status: "err", payload: "UNEXPECTED_DISCONNECT" },

--- a/tests/instance_mismatch.ts
+++ b/tests/instance_mismatch.ts
@@ -43,7 +43,7 @@ const MismatchedServerInstanceDoesntGetResentStaleMessagesFromClient: Test = {
           proc: "upload.send",
           payload: { part: "abc" },
         },
-        { type: "wait", ms: 3000 },
+        { type: "sleep", ms: 3000 },
         {
           type: "invoke",
           id: "1",
@@ -63,7 +63,7 @@ const MismatchedServerInstanceDoesntGetResentStaleMessagesFromClient: Test = {
     },
   },
   server: {
-    serverActions: [{ type: "wait", ms: 100 }, { type: "restart_container" }],
+    serverActions: [{ type: "sleep", ms: 100 }, { type: "restart_container" }],
   },
 };
 

--- a/tests/network.ts
+++ b/tests/network.ts
@@ -1,4 +1,4 @@
-import type { Action, ExpectedOutputEntry, Test } from "../src/actions";
+import type { ClientAction, ExpectedOutputEntry, Test } from "../src/actions";
 import { WS_DISCONNECT_PERIOD_MS, SESSION_DISCONNECT_MS } from "./constants";
 
 const SurvivesTransientNetworkBlips: Test = {
@@ -12,7 +12,7 @@ const SurvivesTransientNetworkBlips: Test = {
           proc: "kv.set",
           payload: { k: "foo", v: 42 },
         },
-        { type: "wait", ms: 500 },
+        { type: "sleep", ms: 500 },
         { type: "disconnect_network" },
         { type: "connect_network" },
         {
@@ -40,9 +40,9 @@ const ShortConnectionDisconnectTest: Test = {
           proc: "kv.set",
           payload: { k: "foo", v: 42 },
         },
-        { type: "wait", ms: 500 },
+        { type: "sleep", ms: 500 },
         { type: "disconnect_network" },
-        { type: "wait", ms: WS_DISCONNECT_PERIOD_MS },
+        { type: "sleep", ms: WS_DISCONNECT_PERIOD_MS },
         { type: "connect_network" },
         {
           type: "invoke",
@@ -70,9 +70,9 @@ const SessionDisconnectTest: Test = {
           proc: "kv.set",
           payload: { k: "foo", v: 42 },
         },
-        { type: "wait", ms: 500 },
+        { type: "sleep", ms: 500 },
         { type: "disconnect_network" },
-        { type: "wait", ms: SESSION_DISCONNECT_MS },
+        { type: "sleep", ms: SESSION_DISCONNECT_MS },
         { type: "connect_network" },
         {
           type: "invoke",
@@ -99,7 +99,7 @@ const SurvivesLongSessionIdle: Test = {
           proc: "kv.set",
           payload: { k: "foo", v: 42 },
         },
-        { type: "wait", ms: 10000 },
+        { type: "sleep", ms: 10000 },
         {
           type: "invoke",
           id: "2",
@@ -127,7 +127,7 @@ const ShouldNotSendBufferAfterSessionDisconnect: Test = {
           payload: { k: "foo", v: 42 },
         },
         { type: "invoke", id: "2", proc: "kv.watch", payload: { k: "foo" } },
-        { type: "wait", ms: 500 },
+        { type: "sleep", ms: 500 },
         { type: "disconnect_network" },
         {
           type: "invoke",
@@ -135,7 +135,7 @@ const ShouldNotSendBufferAfterSessionDisconnect: Test = {
           proc: "kv.set",
           payload: { k: "foo", v: 43 },
         },
-        { type: "wait", ms: SESSION_DISCONNECT_MS },
+        { type: "sleep", ms: SESSION_DISCONNECT_MS },
         { type: "connect_network" },
         { type: "invoke", id: "4", proc: "kv.watch", payload: { k: "foo" } },
         {
@@ -162,7 +162,7 @@ const BufferedMessagesShouldTakePrecedenceOverNewMessages: Test = {
   clients: {
     client: {
       actions: [
-        { type: "wait", ms: 500 },
+        { type: "sleep", ms: 500 },
         { type: "disconnect_network" },
         { type: "invoke", id: "1", proc: "repeat.echo", init: {} },
         {
@@ -197,18 +197,18 @@ const MessageOrderingPreservedDuringDisconnect: Test = {
           proc: "kv.set",
           payload: { k: "foo", v: 42 },
         },
-        { type: "wait", ms: 500 },
+        { type: "sleep", ms: 500 },
         { type: "disconnect_network" },
         ...Array.from(
           { length: 10 },
-          (_, i): Action => ({
+          (_, i): ClientAction => ({
             type: "invoke",
             id: (i + 2).toString(),
             proc: "kv.set",
             payload: { k: "foo", v: i },
           }),
         ),
-        { type: "wait", ms: WS_DISCONNECT_PERIOD_MS },
+        { type: "sleep", ms: WS_DISCONNECT_PERIOD_MS },
         { type: "connect_network" },
       ],
       expectedOutput: [
@@ -272,7 +272,7 @@ const SubscriptionDisconnectTest: Test = {
           payload: { k: "foo", v: 42 },
         },
         { type: "invoke", id: "2", proc: "kv.watch", payload: { k: "foo" } },
-        { type: "wait", ms: 800 },
+        { type: "sleep", ms: 800 },
         { type: "disconnect_network" },
         {
           type: "invoke",
@@ -308,7 +308,7 @@ const SubscriptionReconnectTest: Test = {
         },
         { type: "invoke", id: "2", proc: "kv.watch", payload: { k: "foo" } },
         { type: "disconnect_network" },
-        { type: "wait", ms: 800 },
+        { type: "sleep", ms: 800 },
         {
           type: "invoke",
           id: "3",
@@ -346,7 +346,7 @@ const TwoClientDisconnectTest: Test = {
           payload: { k: "foo", v: 42 },
         },
         { type: "invoke", id: "2", proc: "kv.watch", payload: { k: "foo" } },
-        { type: "wait", ms: 500 },
+        { type: "sleep", ms: 500 },
         { type: "disconnect_network" },
         {
           type: "invoke",
@@ -354,7 +354,7 @@ const TwoClientDisconnectTest: Test = {
           proc: "kv.set",
           payload: { k: "foo", v: 1 },
         },
-        { type: "wait", ms: 500 },
+        { type: "sleep", ms: 500 },
         { type: "connect_network" },
       ],
       expectedOutput: [
@@ -367,7 +367,7 @@ const TwoClientDisconnectTest: Test = {
     },
     client2: {
       actions: [
-        { type: "wait", ms: 800 },
+        { type: "sleep", ms: 800 },
         { type: "invoke", id: "5", proc: "kv.watch", payload: { k: "foo" } },
         {
           type: "invoke",
@@ -387,6 +387,7 @@ const TwoClientDisconnectTest: Test = {
 };
 
 const RepeatedConnectReconnectTest: Test = {
+  flaky: true,
   clients: {
     client: {
       actions: [
@@ -409,7 +410,7 @@ const RepeatedConnectReconnectTest: Test = {
           payload: { k: "foo", v: 44 },
         },
         { type: "disconnect_network" },
-        { type: "wait", ms: 500 },
+        { type: "sleep", ms: 500 },
         { type: "connect_network" },
         {
           type: "invoke",
@@ -430,7 +431,7 @@ const RepeatedConnectReconnectTest: Test = {
           payload: { k: "foo", v: 47 },
         },
         { type: "disconnect_network" },
-        { type: "wait", ms: 500 },
+        { type: "sleep", ms: 500 },
         { type: "connect_network" },
         {
           type: "invoke",
@@ -476,10 +477,10 @@ const WatchDuringDisconnect: Test = {
           proc: "kv.set",
           payload: { k: "foo", v: 42 },
         },
-        { type: "wait", ms: 500 },
+        { type: "sleep", ms: 500 },
         { type: "disconnect_network" },
         { type: "invoke", id: "2", proc: "kv.watch", payload: { k: "foo" } },
-        { type: "wait", ms: WS_DISCONNECT_PERIOD_MS },
+        { type: "sleep", ms: WS_DISCONNECT_PERIOD_MS },
         { type: "connect_network" },
         {
           type: "invoke",
@@ -510,14 +511,14 @@ const ShortDisconnectMultipleTimes: Test = {
           payload: { k: "foo", v: 42 },
         },
         { type: "invoke", id: "2", proc: "kv.watch", payload: { k: "foo" } },
-        { type: "wait", ms: 500 },
+        { type: "sleep", ms: 500 },
         { type: "disconnect_network" },
         { type: "invoke", id: "3", proc: "kv.watch", payload: { k: "foo" } },
-        { type: "wait", ms: WS_DISCONNECT_PERIOD_MS },
+        { type: "sleep", ms: WS_DISCONNECT_PERIOD_MS },
         { type: "connect_network" },
-        { type: "wait", ms: 500 },
+        { type: "sleep", ms: 500 },
         { type: "disconnect_network" },
-        { type: "wait", ms: WS_DISCONNECT_PERIOD_MS },
+        { type: "sleep", ms: WS_DISCONNECT_PERIOD_MS },
         { type: "connect_network" },
         {
           type: "invoke",
@@ -549,9 +550,9 @@ const DisconnectMultipleTimes: Test = {
           proc: "kv.set",
           payload: { k: "foo", v: 42 },
         },
-        { type: "wait", ms: 500 },
+        { type: "sleep", ms: 500 },
         { type: "disconnect_network" },
-        { type: "wait", ms: SESSION_DISCONNECT_MS },
+        { type: "sleep", ms: SESSION_DISCONNECT_MS },
         { type: "connect_network" },
         {
           type: "invoke",
@@ -559,9 +560,9 @@ const DisconnectMultipleTimes: Test = {
           proc: "kv.set",
           payload: { k: "foo", v: 43 },
         },
-        { type: "wait", ms: 3000 }, // give some buffer for budget to restore
+        { type: "sleep", ms: 3000 }, // give some buffer for budget to restore
         { type: "disconnect_network" },
-        { type: "wait", ms: SESSION_DISCONNECT_MS },
+        { type: "sleep", ms: SESSION_DISCONNECT_MS },
         { type: "connect_network" },
         {
           type: "invoke",
@@ -591,7 +592,7 @@ const ComplexSituation: Test = {
           proc: "kv.set",
           payload: { k: "foo", v: 42 },
         },
-        { type: "wait", ms: SESSION_DISCONNECT_MS },
+        { type: "sleep", ms: SESSION_DISCONNECT_MS },
         { type: "invoke", id: "2", proc: "kv.watch", payload: { k: "foo" } },
         {
           type: "invoke",
@@ -599,7 +600,7 @@ const ComplexSituation: Test = {
           proc: "kv.set",
           payload: { k: "foo", v: 43 },
         },
-        { type: "wait", ms: WS_DISCONNECT_PERIOD_MS },
+        { type: "sleep", ms: WS_DISCONNECT_PERIOD_MS },
         { type: "invoke", id: "4", proc: "kv.watch", payload: { k: "foo" } },
         {
           type: "invoke",
@@ -607,7 +608,7 @@ const ComplexSituation: Test = {
           proc: "kv.set",
           payload: { k: "foo", v: 44 },
         },
-        { type: "wait", ms: SESSION_DISCONNECT_MS },
+        { type: "sleep", ms: SESSION_DISCONNECT_MS },
         { type: "invoke", id: "6", proc: "kv.watch", payload: { k: "foo" } },
         {
           type: "invoke",
@@ -615,9 +616,9 @@ const ComplexSituation: Test = {
           proc: "kv.set",
           payload: { k: "foo", v: 45 },
         },
-        { type: "wait", ms: 500 },
+        { type: "sleep", ms: 500 },
         { type: "disconnect_network" },
-        { type: "wait", ms: SESSION_DISCONNECT_MS },
+        { type: "sleep", ms: SESSION_DISCONNECT_MS },
         { type: "connect_network" },
         {
           type: "invoke",
@@ -625,7 +626,7 @@ const ComplexSituation: Test = {
           proc: "kv.set",
           payload: { k: "foo", v: 42 },
         },
-        { type: "wait", ms: SESSION_DISCONNECT_MS },
+        { type: "sleep", ms: SESSION_DISCONNECT_MS },
         { type: "invoke", id: "12", proc: "kv.watch", payload: { k: "foo" } },
         {
           type: "invoke",
@@ -634,7 +635,7 @@ const ComplexSituation: Test = {
           payload: { k: "foo", v: 43 },
         },
         { type: "disconnect_network" },
-        { type: "wait", ms: WS_DISCONNECT_PERIOD_MS },
+        { type: "sleep", ms: WS_DISCONNECT_PERIOD_MS },
         { type: "connect_network" },
         { type: "invoke", id: "14", proc: "kv.watch", payload: { k: "foo" } },
         {
@@ -643,7 +644,7 @@ const ComplexSituation: Test = {
           proc: "kv.set",
           payload: { k: "foo", v: 44 },
         },
-        { type: "wait", ms: SESSION_DISCONNECT_MS },
+        { type: "sleep", ms: SESSION_DISCONNECT_MS },
         { type: "invoke", id: "16", proc: "kv.watch", payload: { k: "foo" } },
         {
           type: "invoke",
@@ -651,7 +652,7 @@ const ComplexSituation: Test = {
           proc: "kv.set",
           payload: { k: "foo", v: 45 },
         },
-        { type: "wait", ms: 500 },
+        { type: "sleep", ms: 500 },
       ],
 
       expectedOutput: [
@@ -697,7 +698,7 @@ const ComplexSituation: Test = {
           proc: "kv.set",
           payload: { k: "bar", v: 12 },
         },
-        { type: "wait", ms: SESSION_DISCONNECT_MS },
+        { type: "sleep", ms: SESSION_DISCONNECT_MS },
         { type: "invoke", id: "2", proc: "kv.watch", payload: { k: "bar" } },
         {
           type: "invoke",
@@ -705,7 +706,7 @@ const ComplexSituation: Test = {
           proc: "kv.set",
           payload: { k: "bar", v: 13 },
         },
-        { type: "wait", ms: WS_DISCONNECT_PERIOD_MS },
+        { type: "sleep", ms: WS_DISCONNECT_PERIOD_MS },
         { type: "invoke", id: "4", proc: "kv.watch", payload: { k: "bar" } },
         {
           type: "invoke",
@@ -720,9 +721,9 @@ const ComplexSituation: Test = {
           proc: "kv.set",
           payload: { k: "bar", v: 15 },
         },
-        { type: "wait", ms: 500 },
+        { type: "sleep", ms: 500 },
         { type: "disconnect_network" },
-        { type: "wait", ms: SESSION_DISCONNECT_MS },
+        { type: "sleep", ms: SESSION_DISCONNECT_MS },
         { type: "connect_network" },
         {
           type: "invoke",
@@ -730,7 +731,7 @@ const ComplexSituation: Test = {
           proc: "kv.set",
           payload: { k: "bar", v: 12 },
         },
-        { type: "wait", ms: SESSION_DISCONNECT_MS },
+        { type: "sleep", ms: SESSION_DISCONNECT_MS },
         { type: "invoke", id: "12", proc: "kv.watch", payload: { k: "bar" } },
         {
           type: "invoke",
@@ -739,7 +740,7 @@ const ComplexSituation: Test = {
           payload: { k: "bar", v: 13 },
         },
         { type: "disconnect_network" },
-        { type: "wait", ms: WS_DISCONNECT_PERIOD_MS },
+        { type: "sleep", ms: WS_DISCONNECT_PERIOD_MS },
         { type: "connect_network" },
         { type: "invoke", id: "14", proc: "kv.watch", payload: { k: "bar" } },
         {
@@ -748,7 +749,7 @@ const ComplexSituation: Test = {
           proc: "kv.set",
           payload: { k: "bar", v: 14 },
         },
-        { type: "wait", ms: SESSION_DISCONNECT_MS },
+        { type: "sleep", ms: SESSION_DISCONNECT_MS },
         { type: "invoke", id: "16", proc: "kv.watch", payload: { k: "bar" } },
         {
           type: "invoke",
@@ -756,7 +757,7 @@ const ComplexSituation: Test = {
           proc: "kv.set",
           payload: { k: "bar", v: 15 },
         },
-        { type: "wait", ms: 500 },
+        { type: "sleep", ms: 500 },
       ],
       expectedOutput: [
         { id: "1", status: "ok", payload: 12 },

--- a/tests/volume.ts
+++ b/tests/volume.ts
@@ -1,4 +1,4 @@
-import type { Action, Test } from "../src/actions";
+import type { ClientAction, Test } from "../src/actions";
 
 const MANY = 5000;
 const ManyRpcs: Test = {
@@ -8,14 +8,14 @@ const ManyRpcs: Test = {
       actions: [
         ...Array.from(
           { length: MANY },
-          (_, i): Action => ({
+          (_, i): ClientAction => ({
             type: "invoke",
             id: (i + 1).toString(),
             proc: "kv.set",
             payload: { k: "foo", v: i },
           }),
         ),
-        { type: "wait", ms: 3000 },
+        { type: "sleep", ms: 3000 },
       ],
       expectedOutput: Array.from({ length: MANY }, (_, i) => ({
         id: (i + 1).toString(),
@@ -34,14 +34,14 @@ const ManyStreams: Test = {
         { type: "invoke", id: "1", proc: "repeat.echo", init: {} },
         ...Array.from(
           { length: MANY },
-          (_, i): Action => ({
+          (_, i): ClientAction => ({
             type: "invoke",
             id: "1",
             proc: "repeat.echo",
             payload: { s: i.toString() },
           }),
         ),
-        { type: "wait", ms: 2000 },
+        { type: "sleep", ms: 2000 },
       ],
       expectedOutput: Array.from({ length: MANY }, (_, i) => ({
         id: "1",


### PR DESCRIPTION
The action types are currently a bit of a mess because we rely on `Exclude` to build the concrete type. But why do all that gymnastics when we can simply declare the type as expected?

This change stops the madness and declares the `ServerAction` and `ClientAction` types separately, and renames `wait` to `sleep` for clarity.