### PR TITLE
Add `sync`

### DIFF
--- a/src/actions.ts
+++ b/src/actions.ts
@@ -1,6 +1,11 @@
 // driver actions for each container
 export type CommonAction =
   | {
+      type: "sync";
+      label: string;
+      timeout?: number;
+    }
+  | {
       type: "sleep";
       ms: number;
     }

--- a/tests/basic/kv.ts
+++ b/tests/basic/kv.ts
@@ -80,7 +80,6 @@ const KvSubscribeErrorTest: Test = {
 };
 
 const KvSubscribeMultipleTest: Test = {
-  flaky: true,
   clients: {
     client1: {
       actions: [
@@ -98,6 +97,7 @@ const KvSubscribeMultipleTest: Test = {
           payload: { k: "foo", v: 43 },
         },
         { type: "wait_response", id: "3" },
+        { type: "sync", label: "43" },
       ],
       expectedOutput: [
         // set foo 42
@@ -115,7 +115,7 @@ const KvSubscribeMultipleTest: Test = {
     },
     client2: {
       actions: [
-        { type: "sleep", ms: 800 },
+        { type: "sync", label: "43" },
         { type: "invoke", id: "a", proc: "kv.watch", payload: { k: "foo" } },
         {
           type: "invoke",

--- a/tests/instance_mismatch.ts
+++ b/tests/instance_mismatch.ts
@@ -32,11 +32,9 @@ const MismatchedClientInstanceDoesntGetResentStaleMessagesFromServer: Test = {
 };
 
 const MismatchedServerInstanceDoesntGetResentStaleMessagesFromClient: Test = {
-  flaky: true,
   clients: {
     client: {
       actions: [
-        { type: "invoke", id: "1", proc: "upload.send", init: {} },
         {
           type: "invoke",
           id: "1",
@@ -44,6 +42,7 @@ const MismatchedServerInstanceDoesntGetResentStaleMessagesFromClient: Test = {
           payload: { k: "foo", v: 42 },
         },
         { type: "wait_response", id: "1" },
+        { type: "sync", label: "1" },
         { type: "invoke", id: "2", proc: "upload.send", init: {} },
         {
           type: "invoke",
@@ -54,24 +53,28 @@ const MismatchedServerInstanceDoesntGetResentStaleMessagesFromClient: Test = {
         { type: "wait_response", id: "2" },
         {
           type: "invoke",
-          id: "1",
+          id: "2",
           proc: "upload.send",
           payload: { part: "def" },
         },
         {
           type: "invoke",
-          id: "1",
+          id: "2",
           proc: "upload.send",
           payload: { part: "EOF" },
         },
       ],
       expectedOutput: [
-        { id: "1", status: "err", payload: "UNEXPECTED_DISCONNECT" },
+        { id: "1", status: "ok", payload: 42 },
+        { id: "2", status: "err", payload: "UNEXPECTED_DISCONNECT" },
       ],
     },
   },
   server: {
-    serverActions: [{ type: "restart_container" }],
+    serverActions: [
+      { type: "sync", label: "1" },
+      { type: "restart_container" },
+    ],
   },
 };
 

--- a/tests/network.ts
+++ b/tests/network.ts
@@ -307,7 +307,7 @@ const SubscriptionReconnectTest: Test = {
         { type: "invoke", id: "2", proc: "kv.watch", payload: { k: "foo" } },
         { type: "wait_response", id: "2" },
         { type: "disconnect_network" },
-        { type: "sleep", ms: 800 },
+        { type: "sleep", ms: 500 },
         {
           type: "invoke",
           id: "3",
@@ -334,7 +334,6 @@ const SubscriptionReconnectTest: Test = {
 };
 
 const TwoClientDisconnectTest: Test = {
-  flaky: true,
   clients: {
     client1: {
       actions: [
@@ -346,6 +345,7 @@ const TwoClientDisconnectTest: Test = {
         },
         { type: "invoke", id: "2", proc: "kv.watch", payload: { k: "foo" } },
         { type: "wait_response", id: "2" },
+        { type: "sync", label: "2" },
         { type: "disconnect_network" },
         {
           type: "invoke",
@@ -353,7 +353,7 @@ const TwoClientDisconnectTest: Test = {
           proc: "kv.set",
           payload: { k: "foo", v: 1 },
         },
-        { type: "sleep", ms: 500 },
+        { type: "sync", label: "6" },
         { type: "connect_network" },
       ],
       expectedOutput: [
@@ -366,7 +366,7 @@ const TwoClientDisconnectTest: Test = {
     },
     client2: {
       actions: [
-        { type: "sleep", ms: 800 },
+        { type: "sync", label: "2" },
         { type: "invoke", id: "5", proc: "kv.watch", payload: { k: "foo" } },
         {
           type: "invoke",
@@ -375,6 +375,7 @@ const TwoClientDisconnectTest: Test = {
           payload: { k: "foo", v: 46 },
         },
         { type: "wait_response", id: "6" },
+        { type: "sync", label: "6" },
       ],
       expectedOutput: [
         { id: "5", status: "ok", payload: 42 },


### PR DESCRIPTION
We still have a few things that need synchronization between containers.

In order to avoid hardcoded sleeps, we can add one more primitive: `sync`, which provides a Barrier-like object that waits until all containers have reached a certain point in their execution.