### PR TITLE
Add `unordered`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -71,7 +71,16 @@ process.on("SIGINT", async () => {
 function constructDiffString(
   expected: string,
   actual: string,
+  unordered: boolean,
 ): [string, boolean] {
+  if (unordered) {
+    const actualLines = actual.split("\n");
+    actualLines.sort();
+    actual = actualLines.join("\n");
+    const expectedLines = expected.split("\n");
+    expectedLines.sort();
+    expected = expectedLines.join("\n");
+  }
   const patch = structuredPatch(
     "expected",
     "actual",
@@ -268,7 +277,11 @@ async function runSuite(
         .map(serializeExpectedOutputEntry)
         .join("\n");
       const actualOutput = await client.stdout;
-      const [diff, hasDiff] = constructDiffString(expectedOutput, actualOutput);
+      const [diff, hasDiff] = constructDiffString(
+        expectedOutput,
+        actualOutput,
+        test.unordered ?? false,
+      );
 
       if (hasDiff) {
         testFailed = true;

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -148,5 +148,9 @@ export type Test = {
   server?: {
     serverActions: ServerAction[];
   };
+  // Flaky means that failing a test case won't mark the test suite as failed.
   flaky?: boolean;
+  // Unordered means that prior to diffing the output, it will be sorted lexicographically.
+  // Useful for tests that have inherent racy output.
+  unordered?: boolean;
 };

--- a/tests/interleaving.ts
+++ b/tests/interleaving.ts
@@ -1,6 +1,7 @@
 import type { Test } from "../src/actions";
 
 const ComplexInterleavingAllProcedures: Test = {
+  unordered: true,
   clients: {
     client: {
       actions: [

--- a/tests/network.ts
+++ b/tests/network.ts
@@ -334,6 +334,7 @@ const SubscriptionReconnectTest: Test = {
 };
 
 const TwoClientDisconnectTest: Test = {
+  unordered: true,
   clients: {
     client1: {
       actions: [
@@ -469,6 +470,7 @@ const RepeatedConnectReconnectTest: Test = {
 };
 
 const WatchDuringDisconnect: Test = {
+  unordered: true,
   clients: {
     client: {
       actions: [


### PR DESCRIPTION
We have a few tests that are inherently racy: they don't have any synchronization primitives inside and furthermore _cannot_ have any synchronization inside them.

This change allows us to tag a few tests as being `unordered`. this means that their outputs will be compared as sets instead of as arrays.